### PR TITLE
Add setSelect(ALL_ATTRIBUTES) to retrieve snapshots

### DIFF
--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -69,7 +69,14 @@ trait CreatePersistenceIdsIndex {
 
 object CreatePersistenceIdsIndex {
 
-  /** required by [[DynamoDBCurrentPersistenceIdsQuery.currentPersistenceIdsByPageQuery]] */
+  /**
+   * required by [[DynamoDBCurrentPersistenceIdsQuery.currentPersistenceIdsByPageQuery]]
+   *
+   * When requesting snapshots by timestamp, Select ALL_ATTRIBUTES is used. Thus, a duplicate of
+   * the payload doesn't need to be stored in the index, which is more space efficient.
+   * This allows to make the choice between time and space efficiency by selecting the projection
+   * strategy for the created index.
+   */
   def createPersistenceIdsIndexRequest(
       indexName: String,
       tableName: String,

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -72,8 +72,8 @@ object CreatePersistenceIdsIndex {
   /**
    * required by [[DynamoDBCurrentPersistenceIdsQuery.currentPersistenceIdsByPageQuery]]
    *
-   * When requesting snapshots by timestamp, Select ALL_ATTRIBUTES is used. Thus, a duplicate of
-   * the payload doesn't need to be stored in the index, which is more space efficient.
+   * Since v1.1.0, when requesting snapshots by timestamp, select ALL_ATTRIBUTES is used. Thus, a
+   * duplicate of the payload doesn't need to be stored in the index, which is more space efficient.
    * This allows to make the choice between time and space efficiency by selecting the projection
    * strategy for the created index.
    */

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotRequests.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.persistence.dynamodb.snapshot
 
 import com.amazonaws.services.dynamodbv2.model._
+import com.amazonaws.services.dynamodbv2.model.Select.ALL_ATTRIBUTES
 import org.apache.pekko
 import pekko.actor.ExtendedActorSystem
 import pekko.persistence.dynamodb._
@@ -106,6 +107,8 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
       .withScanIndexForward(false)
       .withConsistentRead(true)
     limit.foreach(request.setLimit(_))
+
+    request.setSelect(ALL_ATTRIBUTES)
 
     dynamo.query(request)
   }


### PR DESCRIPTION
By doing so, the indexes don't need to have ProjectionStrategy ALL, but KEYS_ONLY suffices. Thus, a duplicate of the payload doesn't need to be stored in the index, which is more space efficient.

This allows to make the choice between time and space efficiency, by selecting the projection strategy for the created index. Depending on the choice, setting this flag for retrieval will make either strategy work as efficient as intended.


**Draft note**

I'm well aware that the rename refactor and deployment processes are still ongoing. We'll adapt these commits to the new reality as it materializes but wanted to stage the contributions already.

Also FYI @coreyoconnor 