### PR TITLE
Build with crossPaths

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -24,7 +24,6 @@ object Publish extends AutoPlugin {
   override def requires = ApacheSonatypePlugin && DynVerPlugin
 
   override lazy val projectSettings = Seq(
-    crossPaths := false,
     homepage := Some(url("https://github.com/apache/pekko-persistence-dynamodb")),
     developers += Developer("contributors",
       "Contributors",


### PR DESCRIPTION
It's uncommon to disable this, and possibly caused the .tasty files in the staged 2.12 and 2.13 artifacts.