### PR TITLE
remove CMSClassUnloadingEnabled from .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -2,4 +2,3 @@
 -Xms1g
 -Xmx4g
 -Xss6M
--XX:+CMSClassUnloadingEnabled


### PR DESCRIPTION
not supported in more recent Java versions