### PR TITLE
use Amazon SDK 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ A replicated Pekko Persistence journal backed by
 - This plugin implements both a journal as well as a snapshot store,
 - This includes a Pekko Persistence Query plugin. However, this requires an additional GSI for efficient usage.
 
-Supported versions:
-- Scala: `2.13.x`, `3.3.0+`
+Apache Pekko Persistence DynamoDB 1.x Supported versions:
+- Scala: `2.12.x`, `2.13.x`, `3.3.0+`
 - Pekko: `1.0.x+`
+- Java: `8+`
+- Amazon SDK for Java v1
+
+Apache Pekko Persistence DynamoDB 2.x Supported versions:
+- Scala: `2.13.x`, `3.3.0+`
+- Pekko: `2.0.x+`
 - Java: `17+`
+- Amazon SDK for Java v2
 
 [![Build Status](https://github.com/apache/pekko-persistence-dynamodb/actions/workflows/check-build-test.yml/badge.svg?branch=main)](https://github.com/apache/pekko-persistence-dynamodb/actions)
 
@@ -115,13 +122,9 @@ In the second case each event is treated in isolation and may or may not be repl
 
 ## Performance Considerations
 
-This plugin uses the AWS Java SDK which means that the number of requests that can be made concurrently is limited by the number of connections to DynamoDB and by the number of threads in the thread-pool that is used by the AWS HTTP client. The default setting is 50 connections which for a deployment that is used from the same EC2 region allows roughly 5000 requests per second (where every persisted event batch is roughly one request). If a single ActorSystem needs to persist more than this number of events per second then you may want to tune the parameter
+This plugin uses the AWS SDK for Java v2 which means that the number of requests that can be made concurrently is limited by the number of connections to DynamoDB and by the number of threads in the thread-pool that is used by the AWS HTTP client. The default SDK configuration allows roughly 5000 requests per second (where every persisted event batch is roughly one request) from the same EC2 region. If a single ActorSystem needs to persist more than this number of events per second then you may want to provide a custom `DynamoDbAsyncClient` with a tuned HTTP client configuration.
 
-~~~
-my-dynamodb-journal.aws-client-config.max-connections = <your value here>
-~~~
-
-Changing this number changes both the number of concurrent connections and the used thread-pool size.
+For advanced HTTP client settings (e.g. max connections, timeouts), provide a custom `DynamoDbAsyncClient`. See the [AWS SDK v2 HTTP configuration documentation](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration.html) for details.
 
 ## Retry behavior
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,15 @@ In the second case each event is treated in isolation and may or may not be repl
 
 ## Performance Considerations
 
-This plugin uses the AWS SDK for Java v2 which means that the number of requests that can be made concurrently is limited by the number of connections to DynamoDB and by the number of threads in the thread-pool that is used by the AWS HTTP client. The default SDK configuration allows roughly 5000 requests per second (where every persisted event batch is roughly one request) from the same EC2 region. If a single ActorSystem needs to persist more than this number of events per second then you may want to provide a custom `DynamoDbAsyncClient` with a tuned HTTP client configuration.
+This plugin uses the AWS SDK for Java v2, which means that the number of requests that can be made concurrently is limited by the concurrency of the SDK's asynchronous HTTP client. The default of 50 concurrent requests allows roughly 5000 requests per second (where every persisted event batch is roughly one request) for a deployment used from the same EC2 region.
 
-For advanced HTTP client settings (e.g. max connections, timeouts), provide a custom `DynamoDbAsyncClient`. See the [AWS SDK v2 HTTP configuration documentation](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration.html) for details.
+The plugin builds its own `DynamoDbAsyncClient` from the settings documented in `reference.conf`, and does not currently expose the SDK's HTTP client settings. In version 1.x these could be tuned through the `aws-client-config` block, for example:
+
+~~~
+my-dynamodb-journal.aws-client-config.max-connections = <your value here>
+~~~
+
+That block was tied to the SDK v1 `ClientConfiguration` class and has been **removed in 2.x**. It is not an error to leave it in `application.conf`, but it no longer has any effect, so remove it when migrating. There is currently no replacement setting; if you need to raise the concurrency limit, please open an issue. See the [AWS SDK v2 HTTP configuration documentation](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration.html) for what the SDK itself supports.
 
 ## Retry behavior
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@
 import com.github.pjfanning.pekkobuild._
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
-val amzVersion = "1.12.797"
+val amzV2Version = "2.34.0"
 val testcontainersScalaVersion = "0.44.1"
 
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
@@ -49,9 +49,7 @@ lazy val root = Project(
     crossScalaVersions := Seq("2.13.18", "3.3.8", "3.8.4"),
     crossVersion := CrossVersion.binary,
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-core" % amzVersion,
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % amzVersion,
-      "javax.xml.bind" % "jaxb-api" % "2.3.1", // see https://github.com/seek-oss/gradle-aws-plugin/issues/15
+      "software.amazon.awssdk" % "dynamodb" % amzV2Version,
       "org.scalatest" %% "scalatest" % "3.2.20" % "test",
       "commons-io" % "commons-io" % "2.22.0" % Test,
       "org.hdrhistogram" % "HdrHistogram" % "2.2.2" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,9 @@ lazy val root = Project(
       "commons-io" % "commons-io" % "2.22.0" % Test,
       "org.hdrhistogram" % "HdrHistogram" % "2.2.2" % Test,
       "com.dimafeng" %% "testcontainers-scala-scalatest" % testcontainersScalaVersion % Test),
+    // no 2.x artifact has been released yet, and 2.0.0 deliberately breaks binary compatibility
+    // with 1.x by moving from the AWS SDK for Java v1 to v2. Restore this once 2.0.0 is out.
+    mimaPreviousArtifacts := Set.empty,
     scalacOptions ++= Seq("-deprecation", "-feature"),
     scalacOptions ++= {
       if (scalaBinaryVersion.value == "3")

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@
 import com.github.pjfanning.pekkobuild._
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
-val amzV2Version = "2.34.0"
+val amzV2Version = "2.47.5"
 val testcontainersScalaVersion = "0.44.1"
 
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -28,7 +28,7 @@ dynamodb-journal {
   replay-dispatcher = "pekko.persistence.dispatchers.default-replay-dispatcher"
 
   # The dispatcher that executes the future combinators needed for
-  # transforming the AmazonDynamoDBAsyncClient results (i.e.
+  # transforming the DynamoDbAsyncClient results (i.e.
   # handling the back-off etc.)
   client-dispatcher = "dynamodb-journal.dispatcher"
 
@@ -50,7 +50,7 @@ dynamodb-journal {
   #
   # It is recommended to leave this (and the aws-secret-access-key) setting
   # empty in order to use the default credentials provider chain, see
-  # https://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain
+  # https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html
   aws-access-key-id = ""
 
   # The AWS secret to use in conjunction with the AWS key ID.
@@ -58,7 +58,7 @@ dynamodb-journal {
   #
   # It is recommended to leave this (and the aws-access-key-id) setting
   # empty in order to use the default credentials provider chain, see
-  # https://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain
+  # https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html
   aws-secret-access-key = ""
 
   # number of concurrently running replay prefetch operations for a
@@ -81,37 +81,11 @@ dynamodb-journal {
     max-item-size = 400000
   }
 
-  # AWS client configuration settings, see
-  # https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/?com/amazonaws/ClientConfiguration.html
-  #
-  # (setting any of these to the string "default" means that the corresponding
-  # setter method on the ClientConfiguration will not be invoked)
+  # AWS client configuration settings.
+  # The AWS SDK v2 DynamoDbAsyncClient is configured via its builder in code.
+  # For advanced HTTP client settings, provide a custom DynamoDbAsyncClient.
+  # See https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration.html
   aws-client-config {
-    client-execution-timeout = default     # int
-    connection-max-idle-millis = default   # long
-    connection-timeout = default           # int
-    connection-ttl = default               # long
-    local-address = default                # InetAddress
-    max-connections = default              # int
-    max-error-retry = default              # int
-    preemptive-basic-proxy-auth = default  # boolean
-    protocol = default                     # HTTP or HTTPS
-    proxy-domain = default                 # string
-    proxy-host = default                   # string
-    proxy-password = default               # string
-    proxy-port = default                   # int
-    proxy-username = default               # string
-    proxy-workstation = default            # string
-    request-timeout = default              # int
-    response-metadata-cache-size = default # int
-    signer-override = default              # string
-    socket-buffer-size-hints = default     # [ int, int ] (for send & receive)
-    socket-timeout = default               # int
-    use-expect-continue = default          # boolean
-    use-gzip = default                     # boolean
-    use-reaper = default                   # boolean
-    use-tcp-keepalive = default            # boolean
-    user-agent = default                   # string
   }
 
   dispatcher {
@@ -154,7 +128,7 @@ dynamodb-snapshot-store {
   endpoint = ${dynamodb-journal.endpoint}
 
   # The dispatcher that executes the future combinators needed for
-  # transforming the AmazonDynamoDBAsyncClient results (i.e.
+  # transforming the DynamoDbAsyncClient results (i.e.
   # handling the back-off etc.)
   client-dispatcher = ${dynamodb-journal.client-dispatcher}
 
@@ -169,7 +143,7 @@ dynamodb-snapshot-store {
   #
   # It is recommended to leave this (and the aws-secret-access-key) setting
   # empty in order to use the default credentials provider chain, see
-  # https://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain
+  # https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html
   aws-access-key-id = ${dynamodb-journal.aws-access-key-id}
 
   # The AWS secret to use in conjuction with the AWS key ID.
@@ -177,7 +151,7 @@ dynamodb-snapshot-store {
   #
   # It is recommended to leave this (and the aws-access-key-id) setting
   # empty in order to use the default credentials provider chain, see
-  # https://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html#using-the-default-credential-provider-chain
+  # https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html
   aws-secret-access-key = ${dynamodb-journal.aws-secret-access-key}
 
   # If this is set to `on` then every DynamoDB request will be logged

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -23,6 +23,13 @@ dynamodb-journal {
   # shall be used. Please refer to the AWS documentation for details.
   endpoint = ""
 
+  # The AWS region to use. Leave empty to use the default region provider chain
+  # (environment variable AWS_REGION, system property aws.region, EC2 instance metadata, etc.).
+  # When specifying a custom endpoint (e.g. for DynamoDB Local), this defaults to us-east-1
+  # if not set.
+  # See https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html
+  region = ""
+
   # The dispatcher that executes the replay logic for this plugin
   # instance - should not normally need to be changed.
   replay-dispatcher = "pekko.persistence.dispatchers.default-replay-dispatcher"
@@ -126,6 +133,9 @@ dynamodb-snapshot-store {
   # The service endpoint to connect to for the DynamoDB instance that
   # shall be used. Please refer to the AWS documentation for details.
   endpoint = ${dynamodb-journal.endpoint}
+
+  # The AWS region to use. Inherits from dynamodb-journal.region by default.
+  region = ${dynamodb-journal.region}
 
   # The dispatcher that executes the future combinators needed for
   # transforming the DynamoDbAsyncClient results (i.e.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -161,8 +161,6 @@ dynamodb-snapshot-store {
   # at DEBUG level. Caution: this will generate A LOT of output.
   tracing = ${dynamodb-journal.tracing}
 
-  aws-client-config =${dynamodb-journal.aws-client-config}
-
   # AWS API limits - DO NOT CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING
   aws-api-limits {
     max-batch-get = ${dynamodb-journal.aws-api-limits.max-batch-get}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -88,13 +88,6 @@ dynamodb-journal {
     max-item-size = 400000
   }
 
-  # AWS client configuration settings.
-  # The AWS SDK v2 DynamoDbAsyncClient is configured via its builder in code.
-  # For advanced HTTP client settings, provide a custom DynamoDbAsyncClient.
-  # See https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration.html
-  aws-client-config {
-  }
-
   dispatcher {
     type = Dispatcher
     executor = "fork-join-executor"

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
@@ -21,6 +21,7 @@ trait DynamoDBConfig {
   val AwsKey: String
   val AwsSecret: String
   val Endpoint: String
+  val Region: String
   val ClientDispatcher: String
   val client: ClientConfig
   val Tracing: Boolean

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
@@ -13,15 +13,10 @@
 
 package org.apache.pekko.persistence.dynamodb
 
-import java.net.InetAddress
-import org.apache.pekko.persistence.dynamodb.journal.DynamoDBHelper
-import org.apache.pekko.serialization.Serialization
-import com.amazonaws.{ ClientConfiguration, Protocol }
 import com.typesafe.config.Config
 
-trait ClientConfig {
-  val config: ClientConfiguration
-}
+trait ClientConfig
+
 trait DynamoDBConfig {
   val AwsKey: String
   val AwsSecret: String
@@ -37,50 +32,4 @@ trait DynamoDBConfig {
 
 }
 
-class DynamoDBClientConfig(c: Config) extends ClientConfig {
-  private val cc = c.getConfig("aws-client-config")
-  private def get[T](path: String, extract: (Config, String) => T, set: T => Unit): Unit =
-    if (cc.getString(path) == "default") ()
-    else {
-      val value = extract(cc, path)
-      set(value)
-      foundSettings ::= s"$path:$value"
-    }
-
-  private var foundSettings = List.empty[String]
-  override lazy val toString: String = foundSettings.reverse.mkString("{", ",", "}")
-  val config = new ClientConfiguration
-
-  get("client-execution-timeout", _.getInt(_), config.setClientExecutionTimeout)
-  get("connection-max-idle-millis", _.getLong(_), config.setConnectionMaxIdleMillis)
-  get("connection-timeout", _.getInt(_), config.setConnectionTimeout)
-  get("connection-ttl", _.getLong(_), config.setConnectionTTL)
-  get("local-address", (c, p) => InetAddress.getByName(c.getString(p)), config.setLocalAddress)
-  get("max-connections", _.getInt(_), config.setMaxConnections)
-  get("max-error-retry", _.getInt(_), config.setMaxErrorRetry)
-  get("preemptive-basic-proxy-auth", _.getBoolean(_), config.withPreemptiveBasicProxyAuth)
-  get("protocol", (c, p) => if (c.getString(p) == "HTTP") Protocol.HTTP else Protocol.HTTPS, config.setProtocol)
-  get("proxy-domain", _.getString(_), config.setProxyDomain)
-  get("proxy-host", _.getString(_), config.setProxyHost)
-  get("proxy-password", _.getString(_), config.setProxyPassword)
-  get("proxy-port", _.getInt(_), config.setProxyPort)
-  get("proxy-username", _.getString(_), config.setProxyUsername)
-  get("proxy-workstation", _.getString(_), config.setProxyWorkstation)
-  get("request-timeout", _.getInt(_), config.setRequestTimeout)
-  get("response-metadata-cache-size", _.getInt(_), config.setResponseMetadataCacheSize)
-  get("signer-override", _.getString(_), config.setSignerOverride)
-  get[(Int, Int)](
-    "socket-buffer-size-hints",
-    (c, p) => {
-      val tuple = c.getIntList(p)
-      require(tuple.size == 2, "socket-buffer-size-hints must be a list of two integers")
-      (tuple.get(0), tuple.get(1))
-    },
-    pair => config.setSocketBufferSizeHints(pair._1, pair._2))
-  get("socket-timeout", _.getInt(_), config.setSocketTimeout)
-  get("use-expect-continue", _.getBoolean(_), config.setUseExpectContinue)
-  get("use-gzip", _.getBoolean(_), config.setUseExpectContinue)
-  get("use-reaper", _.getBoolean(_), config.setUseReaper)
-  get("use-tcp-keepalive", _.getBoolean(_), config.setUseTcpKeepAlive)
-  get("user-agent", _.getString(_), config.setUserAgentPrefix)
-}
+class DynamoDBClientConfig(c: Config) extends ClientConfig

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBConfig.scala
@@ -13,17 +13,12 @@
 
 package org.apache.pekko.persistence.dynamodb
 
-import com.typesafe.config.Config
-
-trait ClientConfig
-
 trait DynamoDBConfig {
   val AwsKey: String
   val AwsSecret: String
   val Endpoint: String
   val Region: String
   val ClientDispatcher: String
-  val client: ClientConfig
   val Tracing: Boolean
   val MaxBatchGet: Int
   val MaxBatchWrite: Int
@@ -32,5 +27,3 @@ trait DynamoDBConfig {
   val JournalName: String
 
 }
-
-class DynamoDBClientConfig(c: Config) extends ClientConfig

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/DynamoDBRequests.scala
@@ -13,9 +13,8 @@
 
 package org.apache.pekko.persistence.dynamodb
 
-import java.util.Collections
 import java.util.{ List => JList, Map => JMap }
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.{ Actor, ActorLogging }
@@ -36,13 +35,17 @@ private[dynamodb] trait DynamoDBRequests {
   import context.dispatcher
   import journalSettings._
 
-  def putItem(item: Item): PutItemRequest = new PutItemRequest().withTableName(Table).withItem(item)
+  def putItem(item: Item): PutItemRequest =
+    PutItemRequest.builder().tableName(Table).item(item).build()
 
   def batchWriteReq(writes: Seq[WriteRequest]): BatchWriteItemRequest =
-    batchWriteReq(Collections.singletonMap(Table, writes.asJava))
+    batchWriteReq(Map(Table -> writes.asJava).asJava)
 
   def batchWriteReq(items: JMap[String, JList[WriteRequest]]): BatchWriteItemRequest =
-    new BatchWriteItemRequest().withRequestItems(items).withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+    BatchWriteItemRequest.builder()
+      .requestItems(items)
+      .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+      .build()
 
   /*
    * Request execution helpers.
@@ -72,18 +75,18 @@ private[dynamodb] trait DynamoDBRequests {
    * the retries from the client, then we are hosed and cannot continue; that is why we have a RuntimeException here
    */
   private def sendUnprocessedItems(
-      result: BatchWriteItemResult,
+      result: BatchWriteItemResponse,
       retriesRemaining: Int = 10,
-      backoff: FiniteDuration = 1.millis): Future[BatchWriteItemResult] = {
-    val unprocessed: Int = result.getUnprocessedItems.get(Table) match {
+      backoff: FiniteDuration = 1.millis): Future[BatchWriteItemResponse] = {
+    val unprocessed: Int = result.unprocessedItems.get(Table) match {
       case null  => 0
       case items => items.size
     }
     if (unprocessed == 0) Future.successful(result)
     else if (retriesRemaining == 0) {
-      throw new RuntimeException(s"unable to batch write ${result.getUnprocessedItems.get(Table)} after 10 tries")
+      throw new RuntimeException(s"unable to batch write ${result.unprocessedItems.get(Table)} after 10 tries")
     } else {
-      val rest = batchWriteReq(result.getUnprocessedItems)
+      val rest = batchWriteReq(result.unprocessedItems)
       after(backoff, context.system.scheduler)(
         dynamo.batchWriteItem(rest).flatMap(r => sendUnprocessedItems(r, retriesRemaining - 1, backoff * 2)))
     }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -22,6 +22,7 @@ import pekko.event.LoggingAdapter
 import pekko.pattern.after
 import pekko.persistence.dynamodb.{ DynamoDBConfig, Item }
 
+import java.util.concurrent.CompletionException
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -84,6 +85,15 @@ trait DynamoDBHelper {
           Future.failed(new DynamoDBJournalFailure("failure while executing " + n, ex))
         case ex: DynamoDbException =>
           Future.failed(ex)
+        case ex: CompletionException if ex.getCause.isInstanceOf[DynamoDbException] =>
+          val cause = ex.getCause.asInstanceOf[DynamoDbException]
+          if (DynamoRetriableException.unapply(cause).isEmpty) {
+            val n = name
+            log.error(cause, "failure while executing {}", n)
+            Future.failed(new DynamoDBJournalFailure("failure while executing " + n, cause))
+          } else {
+            Future.failed(cause)
+          }
       }
     }
 

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -168,8 +168,15 @@ trait DynamoDBHelper {
   def deleteItem(aws: DeleteItemRequest): Future[DeleteItemResponse] =
     send(s"DeleteItemRequest(${aws.tableName},${formatKey(aws.key)})", dynamoDB.deleteItem(aws).asScala)
 
-  def batchWriteItem(aws: BatchWriteItemRequest): Future[BatchWriteItemResponse] =
-    send(s"BatchWriteItemRequest(${aws.requestItems.keySet.iterator.next})", dynamoDB.batchWriteItem(aws).asScala)
+  def batchWriteItem(aws: BatchWriteItemRequest): Future[BatchWriteItemResponse] = {
+    val entry = aws.requestItems.entrySet.iterator.next()
+    val table = entry.getKey
+    val keys = entry.getValue.asScala.map { write =>
+      if (write.deleteRequest != null) "del" + formatKey(write.deleteRequest.key)
+      else "put" + formatKey(write.putRequest.item)
+    }
+    send(s"BatchWriteItemRequest($table, ${keys.mkString("(", ",", ")")})", dynamoDB.batchWriteItem(aws).asScala)
+  }
 
   def batchGetItem(aws: BatchGetItemRequest): Future[BatchGetItemResponse] = {
     val entry = aws.requestItems.entrySet.iterator.next()

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -171,20 +171,26 @@ trait DynamoDBHelper {
     send(s"DeleteItemRequest(${aws.tableName},${formatKey(aws.key)})", dynamoDB.deleteItem(aws).asScala)
 
   def batchWriteItem(aws: BatchWriteItemRequest): Future[BatchWriteItemResponse] = {
-    val entry = aws.requestItems.entrySet.iterator.next()
-    val table = entry.getKey
-    val keys = entry.getValue.asScala.map { write =>
-      if (write.deleteRequest != null) "del" + formatKey(write.deleteRequest.key)
-      else "put" + formatKey(write.putRequest.item)
+    // by-name: only formatted when tracing is on or the request fails
+    def name = {
+      val entry = aws.requestItems.entrySet.iterator.next()
+      val keys = entry.getValue.asScala.map { write =>
+        if (write.deleteRequest != null) "del" + formatKey(write.deleteRequest.key)
+        else "put" + formatKey(write.putRequest.item)
+      }
+      s"BatchWriteItemRequest(${entry.getKey}, ${keys.mkString("(", ",", ")")})"
     }
-    send(s"BatchWriteItemRequest($table, ${keys.mkString("(", ",", ")")})", dynamoDB.batchWriteItem(aws).asScala)
+    send(name, dynamoDB.batchWriteItem(aws).asScala)
   }
 
   def batchGetItem(aws: BatchGetItemRequest): Future[BatchGetItemResponse] = {
-    val entry = aws.requestItems.entrySet.iterator.next()
-    val table = entry.getKey
-    val keys = entry.getValue.keys.asScala.map(formatKey)
-    send(s"BatchGetItemRequest($table, ${keys.mkString("(", ",", ")")})", dynamoDB.batchGetItem(aws).asScala)
+    // by-name: only formatted when tracing is on or the request fails
+    def name = {
+      val entry = aws.requestItems.entrySet.iterator.next()
+      val keys = entry.getValue.keys.asScala.map(formatKey)
+      s"BatchGetItemRequest(${entry.getKey}, ${keys.mkString("(", ",", ")")})"
+    }
+    send(name, dynamoDB.batchGetItem(aws).asScala)
   }
 
 }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -80,11 +80,13 @@ trait DynamoDBHelper {
     def sendSingle(): Future[Out] = {
       call.recoverWith {
         case DynamoRetriableException(ex) =>
+          // don't log at ERROR here — the retry handler will log at WARNING and retry;
+          // only log at ERROR if retries are eventually exhausted
+          Future.failed(ex)
+        case ex: DynamoDbException =>
           val n = name
           log.error(ex, "failure while executing {}", n)
           Future.failed(new DynamoDBJournalFailure("failure while executing " + n, ex))
-        case ex: DynamoDbException =>
-          Future.failed(ex)
         case ex: CompletionException if ex.getCause.isInstanceOf[DynamoDbException] =>
           val cause = ex.getCause.asInstanceOf[DynamoDbException]
           if (DynamoRetriableException.unapply(cause).isEmpty) {

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -27,6 +27,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
+import scala.util.control.NonFatal
 
 case class LatencyReport(nanos: Long, retries: Int)
 private class RetryStateHolder(var retries: Int = 10, var backoff: FiniteDuration = 1.millis)
@@ -78,23 +79,28 @@ trait DynamoDBHelper {
   private def send[Out](name: => String, call: => Future[Out]): Future[Out] = {
 
     def sendSingle(): Future[Out] = {
-      call.recoverWith {
-        case DynamoRetriableException(ex) =>
-          // don't log at ERROR here — the retry handler will log at WARNING and retry;
-          // only log at ERROR if retries are eventually exhausted
-          Future.failed(ex)
-        case ex: DynamoDbException =>
-          val n = name
-          log.error(ex, "failure while executing {}", n)
-          Future.failed(new DynamoDBJournalFailure("failure while executing " + n, ex))
-        case ex: CompletionException if ex.getCause.isInstanceOf[DynamoDbException] =>
-          val cause = ex.getCause.asInstanceOf[DynamoDbException]
-          if (DynamoRetriableException.unapply(cause).isEmpty) {
-            val n = name
-            log.error(cause, "failure while executing {}", n)
-            Future.failed(new DynamoDBJournalFailure("failure while executing " + n, cause))
-          } else {
-            Future.failed(cause)
+      // the client can also fail while preparing the request, before it returns a future
+      val started =
+        try call
+        catch { case NonFatal(ex) => Future.failed(ex) }
+
+      started.recoverWith {
+        case ex =>
+          // the SDK completes its CompletableFuture exceptionally, and the conversion to a Scala
+          // Future keeps the CompletionException that CompletableFuture wraps the cause in
+          val cause = ex match {
+            case ce: CompletionException if ce.getCause ne null => ce.getCause
+            case _                                              => ex
+          }
+          cause match {
+            case DynamoRetriableException(retriable) =>
+              // not logged here: the retry handler logs at WARNING and retries, and logs
+              // at ERROR once the retries are exhausted
+              Future.failed(retriable)
+            case _ =>
+              val n = name
+              log.error(cause, "failure while executing {}", n)
+              Future.failed(new DynamoDBJournalFailure("failure while executing " + n, cause))
           }
       }
     }
@@ -110,7 +116,10 @@ trait DynamoDBHelper {
         after(backoff, scheduler)(sendSingle().recoverWith(retry))
       case other: DynamoDBJournalFailure => Future.failed(other)
       case other                         =>
+        // only reached when the retries for a retriable failure are exhausted; anything else has
+        // already been logged and wrapped by sendSingle
         val n = name
+        log.error(other, "failure while executing {}, no retries left", n)
         Future.failed(new DynamoDBJournalFailure("failed retry " + n, other))
     }
 

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -79,7 +79,7 @@ trait DynamoDBHelper {
 
     def sendSingle(): Future[Out] = {
       call.recoverWith {
-        case ex: DynamoDbException if DynamoRetriableException.unapply(ex).isEmpty =>
+        case DynamoRetriableException(ex) =>
           val n = name
           log.error(ex, "failure while executing {}", n)
           Future.failed(new DynamoDBJournalFailure("failure while executing " + n, ex))

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -72,7 +72,7 @@ trait DynamoDBHelper {
 
   def shutdown(): Unit = dynamoDB.close()
 
-  private var reporter: ActorRef = _
+  private var reporter: ActorRef = null
   def setReporter(ref: ActorRef): Unit = reporter = ref
 
   private def send[Out](name: => String, call: => Future[Out]): Future[Out] = {
@@ -138,7 +138,7 @@ trait DynamoDBHelper {
   }
 
   def listTables(aws: ListTablesRequest): Future[ListTablesResponse] =
-    send(s"ListTablesRequest", dynamoDB.listTables(aws).asScala)
+    send("ListTablesRequest", dynamoDB.listTables(aws).asScala)
 
   def describeTable(aws: DescribeTableRequest): Future[DescribeTableResponse] =
     send(s"DescribeTableRequest(${aws.tableName})", dynamoDB.describeTable(aws).asScala)

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBHelper.scala
@@ -13,10 +13,8 @@
 
 package org.apache.pekko.persistence.dynamodb.journal
 
-import com.amazonaws.{ AmazonServiceException, AmazonWebServiceRequest }
-import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model._
 import org.apache.pekko
 import pekko.actor.{ ActorRef, Scheduler }
 import pekko.annotation.InternalApi
@@ -24,11 +22,10 @@ import pekko.event.LoggingAdapter
 import pekko.pattern.after
 import pekko.persistence.dynamodb.{ DynamoDBConfig, Item }
 
-import java.util.{ concurrent => juc }
-
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 
 case class LatencyReport(nanos: Long, retries: Int)
 private class RetryStateHolder(var retries: Int = 10, var backoff: FiniteDuration = 1.millis)
@@ -38,12 +35,12 @@ private class RetryStateHolder(var retries: Int = 10, var backoff: FiniteDuratio
  */
 @InternalApi
 private object DynamoRetriableException {
-  def unapply(ex: AmazonServiceException) = {
+  def unapply(ex: DynamoDbException) = {
     ex match {
       // 50x network glitches
       case _: InternalServerErrorException =>
         Some(ex)
-      case ase if ase.getStatusCode >= 502 && ase.getStatusCode <= 504 =>
+      case dbe if dbe.statusCode() >= 502 && dbe.statusCode() <= 504 =>
         // retry on more common server errors
         Some(ex)
 
@@ -54,7 +51,7 @@ private object DynamoRetriableException {
         // rate of on-demand requests exceeds the allowed account throughput
         // and the table cannot be scaled further
         Some(ex)
-      case ase if ase.getErrorCode == "ThrottlingException" =>
+      case dbe if dbe.awsErrorDetails != null && dbe.awsErrorDetails.errorCode == "ThrottlingException" =>
         // rate of AWS requests exceeds the allowed throughput
         Some(ex)
       case _ =>
@@ -67,46 +64,27 @@ trait DynamoDBHelper {
 
   implicit val ec: ExecutionContext
   val scheduler: Scheduler
-  val dynamoDB: AmazonDynamoDBAsync
+  val dynamoDB: DynamoDbAsyncClient
   val log: LoggingAdapter
   val settings: DynamoDBConfig
   import settings._
 
-  def shutdown(): Unit = dynamoDB.shutdown()
+  def shutdown(): Unit = dynamoDB.close()
 
-  private var reporter: ActorRef = null
+  private var reporter: ActorRef = _
   def setReporter(ref: ActorRef): Unit = reporter = ref
 
-  private def send[In <: AmazonWebServiceRequest, Out](aws: In, func: AsyncHandler[In, Out] => juc.Future[Out])(implicit
-      d: Describe[? >: In]): Future[Out] = {
-
-    def name = d.desc(aws)
+  private def send[Out](name: => String, call: => Future[Out]): Future[Out] = {
 
     def sendSingle(): Future[Out] = {
-      val p = Promise[Out]()
-
-      val handler = new AsyncHandler[In, Out] {
-        override def onError(ex: Exception) =
-          ex match {
-            case DynamoRetriableException(_) =>
-              p.tryFailure(ex)
-            case _ =>
-              val n = name
-              log.error(ex, "failure while executing {}", n)
-              p.tryFailure(new DynamoDBJournalFailure("failure while executing " + n, ex))
-          }
-        override def onSuccess(req: In, resp: Out) = p.trySuccess(resp)
+      call.recoverWith {
+        case ex: DynamoDbException if DynamoRetriableException.unapply(ex).isEmpty =>
+          val n = name
+          log.error(ex, "failure while executing {}", n)
+          Future.failed(new DynamoDBJournalFailure("failure while executing " + n, ex))
+        case ex: DynamoDbException =>
+          Future.failed(ex)
       }
-
-      try {
-        func(handler)
-      } catch {
-        case ex: Throwable =>
-          log.error(ex, "failure while preparing {}", name)
-          p.tryFailure(ex)
-      }
-
-      p.future
     }
 
     val state = new RetryStateHolder
@@ -135,103 +113,59 @@ trait DynamoDBHelper {
     f
   }
 
-  trait Describe[T] {
-    def desc(t: T): String
-    protected def formatKey(i: Item): String = {
-      val key = i.get(Key) match {
-        case null => "<none>"
-        case x    => x.getS
-      }
-      val sort = i.get(Sort) match {
-        case null => "<none>"
-        case x    => x.getN
-      }
-      s"[$Key=$key,$Sort=$sort]"
+  protected def formatKey(i: Item): String = {
+    val key = i.get(Key) match {
+      case null => "<none>"
+      case x    => x.s
     }
-  }
-
-  object Describe {
-    implicit object GenericDescribe extends Describe[AmazonWebServiceRequest] {
-      def desc(aws: AmazonWebServiceRequest): String = aws.getClass.getSimpleName
+    val sort = i.get(Sort) match {
+      case null => "<none>"
+      case x    => x.n
     }
+    s"[$Key=$key,$Sort=$sort]"
   }
 
-  implicit object DescribeDescribe extends Describe[DescribeTableRequest] {
-    def desc(aws: DescribeTableRequest): String = s"DescribeTableRequest(${aws.getTableName})"
+  def listTables(aws: ListTablesRequest): Future[ListTablesResponse] =
+    send(s"ListTablesRequest", dynamoDB.listTables(aws).asScala)
+
+  def describeTable(aws: DescribeTableRequest): Future[DescribeTableResponse] =
+    send(s"DescribeTableRequest(${aws.tableName})", dynamoDB.describeTable(aws).asScala)
+
+  def createTable(aws: CreateTableRequest): Future[CreateTableResponse] =
+    send(s"CreateTableRequest(${aws.tableName})", dynamoDB.createTable(aws).asScala)
+
+  def updateTable(aws: UpdateTableRequest): Future[UpdateTableResponse] =
+    send(s"UpdateTableRequest(${aws.tableName})", dynamoDB.updateTable(aws).asScala)
+
+  def deleteTable(aws: DeleteTableRequest): Future[DeleteTableResponse] =
+    send(s"DeleteTableRequest(${aws.tableName})", dynamoDB.deleteTable(aws).asScala)
+
+  def query(aws: QueryRequest): Future[QueryResponse] =
+    send(s"QueryRequest(${aws.tableName},${aws.expressionAttributeValues})", dynamoDB.query(aws).asScala)
+
+  def scan(aws: ScanRequest): Future[ScanResponse] =
+    send(s"ScanRequest(${aws.tableName})", dynamoDB.scan(aws).asScala)
+
+  def putItem(aws: PutItemRequest): Future[PutItemResponse] =
+    send(s"PutItemRequest(${aws.tableName},${formatKey(aws.item)})", dynamoDB.putItem(aws).asScala)
+
+  def getItem(aws: GetItemRequest): Future[GetItemResponse] =
+    send(s"GetItemRequest(${aws.tableName})", dynamoDB.getItem(aws).asScala)
+
+  def updateItem(aws: UpdateItemRequest): Future[UpdateItemResponse] =
+    send(s"UpdateItemRequest(${aws.tableName})", dynamoDB.updateItem(aws).asScala)
+
+  def deleteItem(aws: DeleteItemRequest): Future[DeleteItemResponse] =
+    send(s"DeleteItemRequest(${aws.tableName},${formatKey(aws.key)})", dynamoDB.deleteItem(aws).asScala)
+
+  def batchWriteItem(aws: BatchWriteItemRequest): Future[BatchWriteItemResponse] =
+    send(s"BatchWriteItemRequest(${aws.requestItems.keySet.iterator.next})", dynamoDB.batchWriteItem(aws).asScala)
+
+  def batchGetItem(aws: BatchGetItemRequest): Future[BatchGetItemResponse] = {
+    val entry = aws.requestItems.entrySet.iterator.next()
+    val table = entry.getKey
+    val keys = entry.getValue.keys.asScala.map(formatKey)
+    send(s"BatchGetItemRequest($table, ${keys.mkString("(", ",", ")")})", dynamoDB.batchGetItem(aws).asScala)
   }
-
-  implicit object QueryDescribe extends Describe[QueryRequest] {
-    def desc(aws: QueryRequest): String = s"QueryRequest(${aws.getTableName},${aws.getExpressionAttributeValues})"
-  }
-
-  implicit object PutItemDescribe extends Describe[PutItemRequest] {
-    def desc(aws: PutItemRequest): String = s"PutItemRequest(${aws.getTableName},${formatKey(aws.getItem)})"
-  }
-
-  implicit object DeleteDescribe extends Describe[DeleteItemRequest] {
-    def desc(aws: DeleteItemRequest): String = s"DeleteItemRequest(${aws.getTableName},${formatKey(aws.getKey)})"
-  }
-
-  implicit object BatchGetItemDescribe extends Describe[BatchGetItemRequest] {
-    def desc(aws: BatchGetItemRequest): String = {
-      val entry = aws.getRequestItems.entrySet.iterator.next()
-      val table = entry.getKey
-      val keys = entry.getValue.getKeys.asScala.map(formatKey)
-      s"BatchGetItemRequest($table, ${keys.mkString("(", ",", ")")})"
-    }
-  }
-
-  implicit object BatchWriteItemDescribe extends Describe[BatchWriteItemRequest] {
-    def desc(aws: BatchWriteItemRequest): String = {
-      val entry = aws.getRequestItems.entrySet.iterator.next()
-      val table = entry.getKey
-      val keys = entry.getValue.asScala.map { write =>
-        write.getDeleteRequest match {
-          case null => "put" + formatKey(write.getPutRequest.getItem)
-          case del  => "del" + formatKey(del.getKey)
-        }
-      }
-      s"BatchWriteItemRequest($table, ${keys.mkString("(", ",", ")")})"
-    }
-  }
-
-  def listTables(aws: ListTablesRequest): Future[ListTablesResult] =
-    send[ListTablesRequest, ListTablesResult](aws, dynamoDB.listTablesAsync(aws, _))
-
-  def describeTable(aws: DescribeTableRequest): Future[DescribeTableResult] =
-    send[DescribeTableRequest, DescribeTableResult](aws, dynamoDB.describeTableAsync(aws, _))
-
-  def createTable(aws: CreateTableRequest): Future[CreateTableResult] =
-    send[CreateTableRequest, CreateTableResult](aws, dynamoDB.createTableAsync(aws, _))
-
-  def updateTable(aws: UpdateTableRequest): Future[UpdateTableResult] =
-    send[UpdateTableRequest, UpdateTableResult](aws, dynamoDB.updateTableAsync(aws, _))
-
-  def deleteTable(aws: DeleteTableRequest): Future[DeleteTableResult] =
-    send[DeleteTableRequest, DeleteTableResult](aws, dynamoDB.deleteTableAsync(aws, _))
-
-  def query(aws: QueryRequest): Future[QueryResult] =
-    send[QueryRequest, QueryResult](aws, dynamoDB.queryAsync(aws, _))
-
-  def scan(aws: ScanRequest): Future[ScanResult] =
-    send[ScanRequest, ScanResult](aws, dynamoDB.scanAsync(aws, _))
-
-  def putItem(aws: PutItemRequest): Future[PutItemResult] =
-    send[PutItemRequest, PutItemResult](aws, dynamoDB.putItemAsync(aws, _))
-
-  def getItem(aws: GetItemRequest): Future[GetItemResult] =
-    send[GetItemRequest, GetItemResult](aws, dynamoDB.getItemAsync(aws, _))
-
-  def updateItem(aws: UpdateItemRequest): Future[UpdateItemResult] =
-    send[UpdateItemRequest, UpdateItemResult](aws, dynamoDB.updateItemAsync(aws, _))
-
-  def deleteItem(aws: DeleteItemRequest): Future[DeleteItemResult] =
-    send[DeleteItemRequest, DeleteItemResult](aws, dynamoDB.deleteItemAsync(aws, _))
-
-  def batchWriteItem(aws: BatchWriteItemRequest): Future[BatchWriteItemResult] =
-    send[BatchWriteItemRequest, BatchWriteItemResult](aws, dynamoDB.batchWriteItemAsync(aws, _))
-
-  def batchGetItem(aws: BatchGetItemRequest): Future[BatchGetItemResult] =
-    send[BatchGetItemRequest, BatchGetItemResult](aws, dynamoDB.batchGetItemAsync(aws, _))
 
 }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -22,7 +22,7 @@ import org.apache.pekko.persistence.{ AtomicWrite, Persistence }
 import org.apache.pekko.persistence.dynamodb._
 import org.apache.pekko.serialization.{ Serialization, SerializationExtension }
 import org.apache.pekko.stream.{ Materializer, SystemMaterializer }
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import com.typesafe.config.Config
 
 import scala.collection.immutable
@@ -97,7 +97,7 @@ class DynamoDBJournal(config: Config)
 
   val dynamo = dynamoClient(context.system, journalSettings)
 
-  dynamo.describeTable(new DescribeTableRequest().withTableName(JournalTable)).onComplete {
+  dynamo.describeTable(DescribeTableRequest.builder().tableName(JournalTable).build()).onComplete {
     case Success(result) => log.info("using DynamoDB table {}", result)
     case _               => log.error("persistent actor requests will fail until the table '{}' is accessible", JournalTable)
   }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
@@ -24,6 +24,7 @@ class DynamoDBJournalConfig(c: Config) extends DynamoDBConfig {
   val AwsKey = c.getString("aws-access-key-id")
   val AwsSecret = c.getString("aws-secret-access-key")
   val Endpoint = c.getString("endpoint")
+  val Region = c.getString("region")
   val ReplayDispatcher = c.getString("replay-dispatcher")
   val ClientDispatcher = c.getString("client-dispatcher")
   val SequenceShards = c.getInt("sequence-shards")

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalConfig.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.persistence.dynamodb.journal
 
 import com.typesafe.config.Config
 
-import org.apache.pekko.persistence.dynamodb.{ DynamoDBClientConfig, DynamoDBConfig }
+import org.apache.pekko.persistence.dynamodb.DynamoDBConfig
 
 class DynamoDBJournalConfig(c: Config) extends DynamoDBConfig {
   val JournalTable = c.getString("journal-table")
@@ -40,7 +40,6 @@ class DynamoDBJournalConfig(c: Config) extends DynamoDBConfig {
     val HighDistrust = c.getBoolean("fixes.high-distrust")
   }
 
-  val client = new DynamoDBClientConfig(c)
   override def toString: String =
     "DynamoDBJournalConfig(" +
     "JournalTable:" + JournalTable +
@@ -56,7 +55,6 @@ class DynamoDBJournalConfig(c: Config) extends DynamoDBConfig {
     ",MaxBatchWrite:" + MaxBatchWrite +
     ",MaxItemSize:" + MaxItemSize +
     ",Fixes.HighDistrust:" + Fixes.HighDistrust +
-    ",client.config:" + client +
     ")"
 }
 

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
@@ -14,14 +14,14 @@
 package org.apache.pekko.persistence.dynamodb.journal
 
 import java.nio.ByteBuffer
-import java.util.Collections
+import java.util.{ Collections, Map => JMap }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import org.apache.pekko
 import pekko.Done
 import pekko.actor.ExtendedActorSystem
@@ -73,7 +73,7 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
       toMsgItem(atomicWrite.payload.head)
         .flatMap { event =>
           try {
-            if (event.get(Sort).getN == "0") {
+            if (event.get(Sort).n == "0") {
               val hs = toHSItem(atomicWrite.persistenceId, atomicWrite.lowestSequenceNr)
               liftUnit(dynamo.batchWriteItem(batchWriteReq(putReq(event) :: putReq(hs) :: Nil)))
             } else {
@@ -126,7 +126,7 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
   def deleteMessages(persistenceId: String, start: Long, end: Long): Future[Done] =
     doBatch(batch => s"execute batch delete $batch", (start to end).map(deleteReq(persistenceId, _)))
 
-  def setHS(persistenceId: String, to: Long): Future[PutItemResult] = {
+  def setHS(persistenceId: String, to: Long): Future[PutItemResponse] = {
     val put = putItem(toHSItem(persistenceId, to))
     dynamo.putItem(put)
   }
@@ -136,7 +136,7 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
       _ => s"remove highest sequence number entry for $persistenceId",
       (0 until SequenceShards).map(deleteHSItem(persistenceId, _)))
 
-  def setLS(persistenceId: String, to: Long): Future[PutItemResult] = {
+  def setLS(persistenceId: String, to: Long): Future[PutItemResponse] = {
     val put = putItem(toLSItem(persistenceId, to))
     dynamo.putItem(put)
   }
@@ -198,7 +198,7 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
 
         val itemSize = keyLength(
           repr.persistenceId,
-          repr.sequenceNr) + eventData.getB.remaining + serializerId.getN.getBytes.length + manifestLength + fieldLength
+          repr.sequenceNr) + eventData.b.asByteArray.length + serializerId.n.getBytes.length + manifestLength + fieldLength
 
         if (itemSize > MaxItemSize) {
           throw new DynamoDBJournalRejection(s"MaxItemSize exceeded: $itemSize > $MaxItemSize")
@@ -240,7 +240,8 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
    * Deleting a highest sequence number entry is done directly by shard number.
    */
   private def deleteHSItem(persistenceId: String, shard: Int): WriteRequest =
-    new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(highSeqKey(persistenceId, shard)))
+    WriteRequest.builder().deleteRequest(
+      DeleteRequest.builder().key(highSeqKey(persistenceId, shard)).build()).build()
 
   /**
    * Store the lowest sequence number for this persistenceId. This is only done
@@ -259,12 +260,15 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
    * Deleting a lowest sequence number entry is done directly by shard number.
    */
   private def deleteLSItem(persistenceId: String, shard: Int): WriteRequest =
-    new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(lowSeqKey(persistenceId, shard)))
+    WriteRequest.builder().deleteRequest(
+      DeleteRequest.builder().key(lowSeqKey(persistenceId, shard)).build()).build()
 
-  private def putReq(item: Item): WriteRequest = new WriteRequest().withPutRequest(new PutRequest().withItem(item))
+  private def putReq(item: Item): WriteRequest =
+    WriteRequest.builder().putRequest(PutRequest.builder().item(item).build()).build()
 
   private def deleteReq(persistenceId: String, sequenceNr: Long): WriteRequest =
-    new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(messageKey(persistenceId, sequenceNr)))
+    WriteRequest.builder().deleteRequest(
+      DeleteRequest.builder().key(messageKey(persistenceId, sequenceNr)).build()).build()
 
   /*
    * Request execution helpers.
@@ -279,19 +283,19 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
    * the retries from the client, then we are hosed and cannot continue; that is why we have a RuntimeException here
    */
   private def sendUnprocessedItems(
-      result: BatchWriteItemResult,
+      result: BatchWriteItemResponse,
       retriesRemaining: Int = 10,
-      backoff: FiniteDuration = 1.millis): Future[BatchWriteItemResult] = {
-    val unprocessed: Int = result.getUnprocessedItems.get(JournalTable) match {
+      backoff: FiniteDuration = 1.millis): Future[BatchWriteItemResponse] = {
+    val unprocessed: Int = result.unprocessedItems.get(JournalTable) match {
       case null  => 0
       case items => items.size
     }
     if (unprocessed == 0) Future.successful(result)
     else if (retriesRemaining == 0) {
       throw new RuntimeException(
-        s"unable to batch write ${result.getUnprocessedItems.get(JournalTable)} after 10 tries")
+        s"unable to batch write ${result.unprocessedItems.get(JournalTable)} after 10 tries")
     } else {
-      val rest = batchWriteReq(result.getUnprocessedItems)
+      val rest = batchWriteReq(result.unprocessedItems)
       after(backoff, context.system.scheduler)(
         dynamo.batchWriteItem(rest).flatMap(r => sendUnprocessedItems(r, retriesRemaining - 1, backoff * 2)))
     }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
@@ -198,7 +198,8 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
 
         val itemSize = keyLength(
           repr.persistenceId,
-          repr.sequenceNr) + eventData.b.asByteArray.length + serializerId.n.getBytes.length + manifestLength + fieldLength
+          repr.sequenceNr) + eventData.b.asByteArray.length + serializerId.n.getBytes.length + manifestLength +
+          fieldLength
 
         if (itemSize > MaxItemSize) {
           throw new DynamoDBJournalRejection(s"MaxItemSize exceeded: $itemSize > $MaxItemSize")

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
@@ -198,7 +198,7 @@ trait DynamoDBJournalRequests extends DynamoDBRequests {
 
         val itemSize = keyLength(
           repr.persistenceId,
-          repr.sequenceNr) + eventData.b.asByteArray.length + serializerId.n.getBytes.length + manifestLength +
+          repr.sequenceNr) + serialized.length + serializerId.n.getBytes.length + manifestLength +
           fieldLength
 
         if (itemSize > MaxItemSize) {

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournalRequests.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.persistence.dynamodb.journal
 
 import java.nio.ByteBuffer
-import java.util.{ Collections, Map => JMap }
+import java.util.Collections
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
@@ -23,10 +23,9 @@ import pekko.serialization.{ AsyncSerializer, Serialization }
 import pekko.stream._
 import pekko.stream.scaladsl._
 import pekko.stream.stage._
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 
-import java.util.function.Consumer
-import java.util.{ ArrayList, Collections, Map => JMap }
+import java.util.{ ArrayList, Map => JMap }
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
@@ -50,7 +49,7 @@ object DynamoDBRecovery {
     def sorted: immutable.Iterable[Item] =
       items.foldLeft(immutable.TreeMap.empty[Long, Item])((acc, i) => acc.updated(itemToSeq(i), i)).map(_._2)
     def ids: Seq[Long] = items.map(itemToSeq).sorted
-    private def itemToSeq(i: Item): Long = map(i.get(Key)) * PartitionSize + i.get(Sort).getN.toInt
+    private def itemToSeq(i: Item): Long = map(i.get(Key)) * PartitionSize + i.get(Sort).n.toInt
   }
 }
 
@@ -144,8 +143,8 @@ object RemoveIncompleteAtoms extends GraphStage[FlowShape[Item, List[Item]]] {
       override def onPush(): Unit = {
         val item = grab(in)
         if (item.containsKey(AtomEnd)) {
-          val end = item.get(AtomEnd).getN.toLong
-          val index = item.get(AtomIndex).getN.toLong
+          val end = item.get(AtomEnd).n.toLong
+          val index = item.get(AtomIndex).n.toLong
           val seqNr = sn(item)
           val myBatchEnd = seqNr - index + end
           if (seqNr == batchEnd) {
@@ -184,8 +183,8 @@ object RemoveIncompleteAtoms extends GraphStage[FlowShape[Item, List[Item]]] {
       }
 
       private def sn(item: Item): Long = {
-        val s = item.get(Key).getS
-        val n = item.get(Sort).getN.toLong
+        val s = item.get(Key).s
+        val n = item.get(Sort).n.toLong
         val pos = s.lastIndexOf('-')
         require(pos != -1, "unknown key format " + s)
         s.substring(pos + 1).toLong * PartitionSize + n
@@ -253,28 +252,28 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
     val endSortKey = sortedNrs.last
 
     val queryRequestBuilder: (Option[java.util.Map[String, AttributeValue]]) => QueryRequest = exclusiveStartKeyOpt => {
-      val request = new QueryRequest()
-        .withTableName(JournalTable)
-        .withKeyConditionExpression(s"$Key = :kkey AND $Sort BETWEEN :startSKey AND :endSKey")
-        .withExpressionAttributeValues(
+      val builder = QueryRequest.builder()
+        .tableName(JournalTable)
+        .keyConditionExpression(s"$Key = :kkey AND $Sort BETWEEN :startSKey AND :endSKey")
+        .expressionAttributeValues(
           Map(
             ":kkey" -> S(messagePartitionKeyFromGroupNr(persistenceId, partitionKeys.partitionSeqNum)),
             ":startSKey" -> N(startSortKey),
             ":endSKey" -> N(endSortKey)).asJava)
-        .withProjectionExpression(ItemAttributesForReplay.mkString(","))
-        .withConsistentRead(true)
-        .withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
-      exclusiveStartKeyOpt.foreach(startKey => request.withExclusiveStartKey(startKey))
-      request
+        .projectionExpression(ItemAttributesForReplay.mkString(","))
+        .consistentRead(true)
+        .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+      exclusiveStartKeyOpt.foreach(startKey => builder.exclusiveStartKey(startKey))
+      builder.build()
     }
 
     def dynamoSummingPager(queryReq: QueryRequest, acc: Seq[Item]): Future[Seq[Item]] = {
       dynamo.query(queryReq).flatMap { result =>
-        val currentPageItems = result.getItems.asScala.toSeq
-        if (result.getLastEvaluatedKey == null || result.getLastEvaluatedKey.isEmpty)
+        val currentPageItems = result.items.asScala.toSeq
+        if (!result.hasLastEvaluatedKey || result.lastEvaluatedKey.isEmpty)
           Future.successful(acc ++ currentPageItems)
         else
-          dynamoSummingPager(queryRequestBuilder(Some(result.getLastEvaluatedKey)), acc ++ currentPageItems)
+          dynamoSummingPager(queryRequestBuilder(Some(result.lastEvaluatedKey)), acc ++ currentPageItems)
       }
     }
 
@@ -309,7 +308,7 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
              * must scan the partition of this Sort=0 entry and find the highest occupied number.
              */
             getAllPartitionSequenceNrs(persistenceId, start).flatMap { result =>
-              if (result.getItems.isEmpty) {
+              if (result.items.isEmpty) {
                 /*
                  * If this comes back empty then that means that all events have been deleted. The only
                  * reliable way to obtain the previously highest number is to also read the lowest number
@@ -323,8 +322,8 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
               } else if (Fixes.HighDistrust) { // allows recovering from failed high mark setting
                 // this function will keep on chasing the event source tail
                 // if HighDistrust is enabled and as long as the partitionMax == PartitionSize - 1
-                def tailChase(partitionStart: Long, nextResults: QueryResult): Future[Long] = {
-                  if (nextResults.getItems.isEmpty) {
+                def tailChase(partitionStart: Long, nextResults: QueryResponse): Future[Long] = {
+                  if (nextResults.items.isEmpty) {
                     // first iteraton will not pass here, as the query result is not empty
                     // if the new query result is empty the highest observed is partition -1
                     Future.successful(partitionStart - 1)
@@ -332,14 +331,14 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
                     /*
                      * `partitionStart` is the Sort=0 entry’s sequence number, so add the maximum sort key.
                      */
-                    val partitionMax = nextResults.getItems.asScala.map(_.get(Sort).getN.toLong).max
+                    val partitionMax = nextResults.items.asScala.map(_.get(Sort).n.toLong).max
                     val ret = partitionStart + partitionMax
 
                     if (partitionMax == PartitionSize - 1) {
                       val nextStart = ret + 1
                       getAllPartitionSequenceNrs(persistenceId, nextStart)
                         .map { logResult =>
-                          if (!logResult.getItems().isEmpty()) // will only log if a follow-up query produced results
+                          if (!logResult.items().isEmpty()) // will only log if a follow-up query produced results
                             log.warning(
                               "readSequenceNr(highest=true persistenceId={}) tail found after {}",
                               persistenceId,
@@ -360,7 +359,7 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
                 /*
                  * `start` is the Sort=0 entry’s sequence number, so add the maximum sort key.
                  */
-                val ret = start + result.getItems.asScala.map(_.get(Sort).getN.toLong).max
+                val ret = start + result.items.asScala.map(_.get(Sort).n.toLong).max
                 log.debug("readSequenceNr(highest=true persistenceId={}) = {}", persistenceId, ret)
                 Future.successful(ret)
               }
@@ -380,53 +379,41 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
       }))
       .map(_.flatten.toSet)
 
-  def readSequenceNrBatches(persistenceId: String, highest: Boolean): Iterator[Future[BatchGetItemResult]] =
+  def readSequenceNrBatches(persistenceId: String, highest: Boolean): Iterator[Future[BatchGetItemResponse]] =
     (0 until SequenceShards).iterator
       .map(l => if (highest) highSeqKey(persistenceId, l) else lowSeqKey(persistenceId, l))
       .grouped(MaxBatchGet)
       .map { keys =>
-        val ka = new KeysAndAttributes().withKeys(keys.asJava).withConsistentRead(true)
-        val get = batchGetReq(Collections.singletonMap(JournalTable, ka))
+        val ka = KeysAndAttributes.builder().keys(keys.asJava).consistentRead(true).build()
+        val get = batchGetReq(Map(JournalTable -> ka).asJava)
         dynamo.batchGetItem(get).flatMap(getUnprocessedItems(_))
       }
 
-  private def getMaxSeqNr(resp: BatchGetItemResult): Long =
-    if (resp.getResponses.isEmpty) 0L
+  private def getMaxSeqNr(resp: BatchGetItemResponse): Long =
+    if (!resp.hasResponses || !resp.responses.containsKey(JournalTable)) 0L
     else {
-      var ret = 0L
-      resp.getResponses
-        .get(JournalTable)
-        .forEach(new Consumer[Item] {
-          override def accept(item: Item): Unit = {
-            val seq = item.get(SequenceNr) match {
-              case null => 0L
-              case attr => attr.getN.toLong
-            }
-            if (seq > ret) ret = seq
-          }
-        })
-      ret
+      resp.responses.get(JournalTable).asScala.foldLeft(0L) { (ret, item) =>
+        val seq = item.get(SequenceNr) match {
+          case null => 0L
+          case attr => attr.n.toLong
+        }
+        if (seq > ret) seq else ret
+      }
     }
 
-  private def getAllSeqNr(resp: BatchGetItemResult): Seq[Long] =
-    if (resp.getResponses.isEmpty()) Nil
+  private def getAllSeqNr(resp: BatchGetItemResponse): Seq[Long] =
+    if (!resp.hasResponses || !resp.responses.containsKey(JournalTable)) Nil
     else {
-      var ret: List[Long] = Nil
-      resp.getResponses
-        .get(JournalTable)
-        .forEach(new Consumer[Item] {
-          override def accept(item: Item): Unit = {
-            item.get(SequenceNr) match {
-              case null =>
-              case attr => ret ::= attr.getN.toLong
-            }
-          }
-        })
-      ret
+      resp.responses.get(JournalTable).asScala.flatMap { item =>
+        item.get(SequenceNr) match {
+          case null => None
+          case attr => Some(attr.n.toLong)
+        }
+      }.toSeq
     }
 
   private def getValueOrEmptyString(item: JMap[String, AttributeValue], key: String): String = {
-    if (item.containsKey(key)) item.get(key).getS else ""
+    if (item.containsKey(key)) item.get(key).s else ""
   }
 
   def readPersistentRepr(item: JMap[String, AttributeValue], async: Boolean): Future[PersistentRepr] = {
@@ -435,23 +422,23 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
     if (item.containsKey(Event)) {
       val serializerManifest = getValueOrEmptyString(item, SerializerManifest)
 
-      val pI = item.get(PersistentId).getS
-      val sN = item.get(SequenceNr).getN.toLong
-      val wU = item.get(WriterUuid).getS
+      val pI = item.get(PersistentId).s
+      val sN = item.get(SequenceNr).n.toLong
+      val wU = item.get(WriterUuid).s
       val reprManifest = getValueOrEmptyString(item, Manifest)
 
-      val eventPayload = item.get(Event).getB
-      val serId = item.get(SerializerId).getN.toInt
+      val eventPayload = item.get(Event).b
+      val serId = item.get(SerializerId).n.toInt
 
       val fut = serialization.serializerByIdentity.get(serId) match {
         case Some(asyncSerializer: AsyncSerializer) =>
           Serialization.withTransportInformation(system.asInstanceOf[ExtendedActorSystem]) { () =>
-            asyncSerializer.fromBinaryAsync(eventPayload.array(), serializerManifest)
+            asyncSerializer.fromBinaryAsync(eventPayload.asByteArray(), serializerManifest)
           }
         case _ =>
           def deserializedEvent: AnyRef = {
             // Serialization.deserialize adds transport info
-            serialization.deserialize(eventPayload.array(), serId, serializerManifest).get
+            serialization.deserialize(eventPayload.asByteArray(), serId, serializerManifest).get
           }
           if (async) Future(deserializedEvent)
           else
@@ -472,7 +459,7 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
 
       def deserializedEvent: PersistentRepr = {
         // Serialization.deserialize adds transport info
-        serialization.deserialize(item.get(Payload).getB.array(), clazz).get
+        serialization.deserialize(item.get(Payload).b.asByteArray(), clazz).get
       }
 
       if (async) Future(deserializedEvent)
@@ -482,56 +469,59 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
     }
   }
 
-  def getUnprocessedItems(result: BatchGetItemResult, retriesRemaining: Int = 10): Future[BatchGetItemResult] = {
-    val unprocessed = result.getUnprocessedKeys.get(JournalTable) match {
-      case null => 0
-      case x    => x.getKeys.size
-    }
-    if (unprocessed == 0) Future.successful(result)
-    else if (retriesRemaining == 0) {
+  def getUnprocessedItems(
+      result: BatchGetItemResponse,
+      allItems: List[Item] = Nil,
+      retriesRemaining: Int = 10): Future[BatchGetItemResponse] = {
+    val currentItems = if (result.hasResponses && result.responses.containsKey(JournalTable))
+      result.responses.get(JournalTable).asScala.toList
+    else Nil
+    val accumulated = allItems ++ currentItems
+
+    val unprocessed = if (result.hasUnprocessedKeys && result.unprocessedKeys.containsKey(JournalTable))
+      result.unprocessedKeys.get(JournalTable).keys.size
+    else 0
+
+    if (unprocessed == 0) {
+      // Build a response with all accumulated items
+      val responseMap = Map(JournalTable -> accumulated.asJava).asJava
+      Future.successful(result.toBuilder.responses(responseMap).unprocessedKeys(Map.empty[String, KeysAndAttributes].asJava).build())
+    } else if (retriesRemaining == 0) {
       Future.failed(
         new DynamoDBJournalFailure(
-          s"unable to batch get ${result.getUnprocessedKeys.get(JournalTable).getKeys} after 10 tries"))
+          s"unable to batch get ${result.unprocessedKeys.get(JournalTable).keys} after 10 tries"))
     } else {
-      val rest = batchGetReq(result.getUnprocessedKeys)
+      val rest = batchGetReq(result.unprocessedKeys)
       dynamo
         .batchGetItem(rest)
-        .map { rr =>
-          val items = rr.getResponses.get(JournalTable)
-          val responses = result.getResponses.get(JournalTable)
-          items.forEach(new Consumer[Item] {
-            override def accept(item: Item): Unit = responses.add(item)
-          })
-          result.setUnprocessedKeys(rr.getUnprocessedKeys)
-          result
-        }
-        .flatMap(getUnprocessedItems(_, retriesRemaining - 1))
+        .flatMap(getUnprocessedItems(_, accumulated, retriesRemaining - 1))
     }
   }
 
-  private[dynamodb] def getAllRemainingQueryItems(request: QueryRequest, result: QueryResult): Future[QueryResult] = {
-    val last = result.getLastEvaluatedKey
-    if (last == null || last.isEmpty || last.get(Sort).getN.toLong == 99) Future.successful(result)
+  private[dynamodb] def getAllRemainingQueryItems(request: QueryRequest, result: QueryResponse): Future[QueryResponse] = {
+    val last = result.lastEvaluatedKey
+    if (!result.hasLastEvaluatedKey || last.isEmpty || last.get(Sort).n.toLong == 99) Future.successful(result)
     else {
-      dynamo.query(request.withExclusiveStartKey(last)).flatMap { next =>
-        val merged = new ArrayList[Item](result.getItems.size + next.getItems.size)
-        merged.addAll(result.getItems)
-        merged.addAll(next.getItems)
+      val nextRequest = request.toBuilder.exclusiveStartKey(last).build()
+      dynamo.query(nextRequest).flatMap { next =>
+        val merged = new ArrayList[Item](result.items.size + next.items.size)
+        merged.addAll(result.items)
+        merged.addAll(next.items)
 
         // need to keep on reading until there's nothing more to read
-        getAllRemainingQueryItems(request, next.withItems(merged))
+        getAllRemainingQueryItems(nextRequest, next.toBuilder.items(merged).build())
       }
     }
   }
 
   def eventQuery(persistenceId: String, sequenceNr: Long) =
-    new QueryRequest()
-      .withTableName(JournalTable)
-      .withKeyConditionExpression(Key + " = :kkey")
-      .withExpressionAttributeValues(
-        Collections.singletonMap(":kkey", S(messagePartitionKey(persistenceId, sequenceNr))))
-      .withProjectionExpression("num")
-      .withConsistentRead(true)
+    QueryRequest.builder()
+      .tableName(JournalTable)
+      .keyConditionExpression(Key + " = :kkey")
+      .expressionAttributeValues(Map(":kkey" -> S(messagePartitionKey(persistenceId, sequenceNr))).asJava)
+      .projectionExpression("num")
+      .consistentRead(true)
+      .build()
 
   private[dynamodb] def getAllPartitionSequenceNrs(persistenceId: String, sequenceNr: Long) = {
     val request = eventQuery(persistenceId, sequenceNr)
@@ -539,7 +529,10 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
   }
 
   def batchGetReq(items: JMap[String, KeysAndAttributes]) =
-    new BatchGetItemRequest().withRequestItems(items).withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+    BatchGetItemRequest.builder()
+      .requestItems(items)
+      .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+      .build()
 
   def logFailure[T](desc: String)(f: Future[T]): Future[T] =
     f.transform(

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
@@ -427,18 +427,20 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
       val wU = item.get(WriterUuid).s
       val reprManifest = getValueOrEmptyString(item, Manifest)
 
+      // asByteArrayUnsafe avoids copying the payload: deserialization only reads the array,
+      // and the response it belongs to is discarded once the event has been read
       val eventPayload = item.get(Event).b
       val serId = item.get(SerializerId).n.toInt
 
       val fut = serialization.serializerByIdentity.get(serId) match {
         case Some(asyncSerializer: AsyncSerializer) =>
           Serialization.withTransportInformation(system.asInstanceOf[ExtendedActorSystem]) { () =>
-            asyncSerializer.fromBinaryAsync(eventPayload.asByteArray(), serializerManifest)
+            asyncSerializer.fromBinaryAsync(eventPayload.asByteArrayUnsafe(), serializerManifest)
           }
         case _ =>
           def deserializedEvent: AnyRef = {
             // Serialization.deserialize adds transport info
-            serialization.deserialize(eventPayload.asByteArray(), serId, serializerManifest).get
+            serialization.deserialize(eventPayload.asByteArrayUnsafe(), serId, serializerManifest).get
           }
           if (async) Future(deserializedEvent)
           else
@@ -459,7 +461,7 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
 
       def deserializedEvent: PersistentRepr = {
         // Serialization.deserialize adds transport info
-        serialization.deserialize(item.get(Payload).b.asByteArray(), clazz).get
+        serialization.deserialize(item.get(Payload).b.asByteArrayUnsafe(), clazz).get
       }
 
       if (async) Future(deserializedEvent)

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
@@ -270,7 +270,7 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
     def dynamoSummingPager(queryReq: QueryRequest, acc: Seq[Item]): Future[Seq[Item]] = {
       dynamo.query(queryReq).flatMap { result =>
         val currentPageItems = result.items.asScala.toSeq
-        if (!result.hasLastEvaluatedKey || result.lastEvaluatedKey.isEmpty)
+        if (!result.hasLastEvaluatedKey)
           Future.successful(acc ++ currentPageItems)
         else
           dynamoSummingPager(queryRequestBuilder(Some(result.lastEvaluatedKey)), acc ++ currentPageItems)
@@ -502,7 +502,7 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
   private[dynamodb] def getAllRemainingQueryItems(request: QueryRequest, result: QueryResponse)
       : Future[QueryResponse] = {
     val last = result.lastEvaluatedKey
-    if (!result.hasLastEvaluatedKey || last.isEmpty || last.get(Sort).n.toLong == 99) Future.successful(result)
+    if (!result.hasLastEvaluatedKey || last.get(Sort).n.toLong == 99) Future.successful(result)
     else {
       val nextRequest = request.toBuilder.exclusiveStartKey(last).build()
       dynamo.query(nextRequest).flatMap { next =>

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
@@ -485,7 +485,8 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
     if (unprocessed == 0) {
       // Build a response with all accumulated items
       val responseMap = Map(JournalTable -> accumulated.asJava).asJava
-      Future.successful(result.toBuilder.responses(responseMap).unprocessedKeys(Map.empty[String, KeysAndAttributes].asJava).build())
+      Future.successful(result.toBuilder.responses(responseMap).unprocessedKeys(Map.empty[String,
+        KeysAndAttributes].asJava).build())
     } else if (retriesRemaining == 0) {
       Future.failed(
         new DynamoDBJournalFailure(
@@ -498,7 +499,8 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
     }
   }
 
-  private[dynamodb] def getAllRemainingQueryItems(request: QueryRequest, result: QueryResponse): Future[QueryResponse] = {
+  private[dynamodb] def getAllRemainingQueryItems(request: QueryRequest, result: QueryResponse)
+      : Future[QueryResponse] = {
     val last = result.lastEvaluatedKey
     if (!result.hasLastEvaluatedKey || last.isEmpty || last.get(Sort).n.toLong == 99) Future.successful(result)
     else {

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
@@ -270,10 +270,10 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
     def dynamoSummingPager(queryReq: QueryRequest, acc: Seq[Item]): Future[Seq[Item]] = {
       dynamo.query(queryReq).flatMap { result =>
         val currentPageItems = result.items.asScala.toSeq
-        if (!result.hasLastEvaluatedKey)
-          Future.successful(acc ++ currentPageItems)
-        else
-          dynamoSummingPager(queryRequestBuilder(Some(result.lastEvaluatedKey)), acc ++ currentPageItems)
+        nonEmptyKey(result.lastEvaluatedKey) match {
+          case None       => Future.successful(acc ++ currentPageItems)
+          case lastKeyOpt => dynamoSummingPager(queryRequestBuilder(lastKeyOpt), acc ++ currentPageItems)
+        }
       }
     }
 
@@ -501,18 +501,18 @@ trait DynamoDBRecovery extends AsyncReplayMessages {
 
   private[dynamodb] def getAllRemainingQueryItems(request: QueryRequest, result: QueryResponse)
       : Future[QueryResponse] = {
-    val last = result.lastEvaluatedKey
-    if (!result.hasLastEvaluatedKey || last.get(Sort).n.toLong == 99) Future.successful(result)
-    else {
-      val nextRequest = request.toBuilder.exclusiveStartKey(last).build()
-      dynamo.query(nextRequest).flatMap { next =>
-        val merged = new ArrayList[Item](result.items.size + next.items.size)
-        merged.addAll(result.items)
-        merged.addAll(next.items)
+    nonEmptyKey(result.lastEvaluatedKey) match {
+      case Some(last) if last.get(Sort).n.toLong != 99 =>
+        val nextRequest = request.toBuilder.exclusiveStartKey(last).build()
+        dynamo.query(nextRequest).flatMap { next =>
+          val merged = new ArrayList[Item](result.items.size + next.items.size)
+          merged.addAll(result.items)
+          merged.addAll(next.items)
 
-        // need to keep on reading until there's nothing more to read
-        getAllRemainingQueryItems(nextRequest, next.toBuilder.items(merged).build())
-      }
+          // need to keep on reading until there's nothing more to read
+          getAllRemainingQueryItems(nextRequest, next.toBuilder.items(merged).build())
+        }
+      case _ => Future.successful(result)
     }
   }
 

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/package.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.persistence.dynamodb
 
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 
 package object journal {
 
@@ -42,12 +42,12 @@ package object journal {
   // This is the size of each partition used on DynamoDB. This value should never change as it will break backwards compatability.
   val PartitionSize: Int = 100
 
-  val schema = new CreateTableRequest()
-    .withKeySchema(
-      new KeySchemaElement().withAttributeName(Key).withKeyType(KeyType.HASH),
-      new KeySchemaElement().withAttributeName(Sort).withKeyType(KeyType.RANGE))
-    .withAttributeDefinitions(
-      new AttributeDefinition().withAttributeName(Key).withAttributeType("S"),
-      new AttributeDefinition().withAttributeName(Sort).withAttributeType("N"))
+  val schema = CreateTableRequest.builder()
+    .keySchema(
+      KeySchemaElement.builder().attributeName(Key).keyType(KeyType.HASH).build(),
+      KeySchemaElement.builder().attributeName(Sort).keyType(KeyType.RANGE).build())
+    .attributeDefinitions(
+      AttributeDefinition.builder().attributeName(Key).attributeType(ScalarAttributeType.S).build(),
+      AttributeDefinition.builder().attributeName(Sort).attributeType(ScalarAttributeType.N).build())
 
 }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/package.scala
@@ -42,7 +42,8 @@ package object journal {
   // This is the size of each partition used on DynamoDB. This value should never change as it will break backwards compatability.
   val PartitionSize: Int = 100
 
-  val schema = CreateTableRequest.builder()
+  // a def, not a val: CreateTableRequest.Builder is mutable, so each caller needs its own
+  def schema: CreateTableRequest.Builder = CreateTableRequest.builder()
     .keySchema(
       KeySchemaElement.builder().attributeName(Key).keyType(KeyType.HASH).build(),
       KeySchemaElement.builder().attributeName(Sort).keyType(KeyType.RANGE).build())

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
@@ -19,6 +19,7 @@ import org.apache.pekko.event.{ Logging, LoggingAdapter }
 import org.apache.pekko.persistence.dynamodb.journal.DynamoDBHelper
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.{ AttributeValue, AttributeValueUpdate }
 
@@ -69,6 +70,14 @@ package object dynamodb {
     if (settings.AwsKey.nonEmpty && settings.AwsSecret.nonEmpty) {
       val creds = AwsBasicCredentials.create(settings.AwsKey, settings.AwsSecret)
       builder.credentialsProvider(StaticCredentialsProvider.create(creds))
+    }
+
+    if (settings.Region.nonEmpty) {
+      builder.region(Region.of(settings.Region))
+    } else if (settings.Endpoint.nonEmpty) {
+      // When using a custom endpoint (e.g. DynamoDB Local), SDK v2 requires a region for
+      // request signing. Fall back to us-east-1 since the region is irrelevant for local endpoints.
+      builder.region(Region.US_EAST_1)
     }
 
     if (settings.Endpoint.nonEmpty) {

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
@@ -73,7 +73,15 @@ package object dynamodb {
     }
 
     if (settings.Region.nonEmpty) {
-      builder.region(Region.of(settings.Region))
+      try {
+        builder.region(Region.of(settings.Region))
+      } catch {
+        case e: IllegalArgumentException =>
+          throw new IllegalArgumentException(
+            s"Invalid AWS region '${settings.Region}' in configuration. " +
+            "See https://docs.aws.amazon.com/general/latest/gr/rande.html for valid region identifiers.",
+            e)
+      }
     } else if (settings.Endpoint.nonEmpty) {
       // When using a custom endpoint (e.g. DynamoDB Local), SDK v2 requires a region for
       // request signing. Fall back to us-east-1 since the region is irrelevant for local endpoints.

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
@@ -13,16 +13,14 @@
 
 package org.apache.pekko.persistence
 
-import java.nio.ByteBuffer
-import java.util.concurrent.Executors
+import java.net.URI
 import org.apache.pekko.actor.{ ActorSystem, Scheduler }
 import org.apache.pekko.event.{ Logging, LoggingAdapter }
 import org.apache.pekko.persistence.dynamodb.journal.DynamoDBHelper
-import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.client.builder.ExecutorFactory
-import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDBAsync, AmazonDynamoDBAsyncClientBuilder }
-import com.amazonaws.services.dynamodbv2.model.{ AttributeValue, AttributeValueUpdate }
+import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.dynamodb.model.{ AttributeValue, AttributeValueUpdate }
 
 import java.util.{ Map => JMap }
 import scala.collection.BuildFrom
@@ -33,13 +31,13 @@ package object dynamodb {
   type Item = JMap[String, AttributeValue]
   type ItemUpdates = JMap[String, AttributeValueUpdate]
 
-  def S(value: String): AttributeValue = new AttributeValue().withS(value)
+  def S(value: String): AttributeValue = AttributeValue.fromS(value)
 
-  def N(value: Long): AttributeValue = new AttributeValue().withN(value.toString)
-  def N(value: String): AttributeValue = new AttributeValue().withN(value)
+  def N(value: Long): AttributeValue = AttributeValue.fromN(value.toString)
+  def N(value: String): AttributeValue = AttributeValue.fromN(value)
   val Naught = N(0)
 
-  def B(value: Array[Byte]): AttributeValue = new AttributeValue().withB(ByteBuffer.wrap(value))
+  def B(value: Array[Byte]): AttributeValue = AttributeValue.fromB(SdkBytes.fromByteArray(value))
 
   def lift[T](f: Future[T]): Future[Try[T]] = {
     val p = Promise[Try[T]]()
@@ -66,26 +64,23 @@ package object dynamodb {
     }.map(_.result())
 
   def dynamoClient(system: ActorSystem, settings: DynamoDBConfig): DynamoDBHelper = {
-    val client = {
-      val builder = AmazonDynamoDBAsyncClientBuilder.standard()
-        .withClientConfiguration(settings.client.config)
-        .withEndpointConfiguration(new EndpointConfiguration(settings.Endpoint, "us-east-1"))
-      if (settings.AwsKey.nonEmpty && settings.AwsSecret.nonEmpty) {
-        val conns = settings.client.config.getMaxConnections
-        val executor = Executors.newFixedThreadPool(conns)
-        val creds = new BasicAWSCredentials(settings.AwsKey, settings.AwsSecret)
-        builder.withCredentials(new AWSStaticCredentialsProvider(creds))
-          .withExecutorFactory(new ExecutorFactory { override def newExecutor() = executor })
-          .build()
-      } else {
-        builder.build()
-      }
+    val builder = DynamoDbAsyncClient.builder()
+
+    if (settings.AwsKey.nonEmpty && settings.AwsSecret.nonEmpty) {
+      val creds = AwsBasicCredentials.create(settings.AwsKey, settings.AwsSecret)
+      builder.credentialsProvider(StaticCredentialsProvider.create(creds))
     }
+
+    if (settings.Endpoint.nonEmpty) {
+      builder.endpointOverride(URI.create(settings.Endpoint))
+    }
+
+    val client = builder.build()
     val dispatcher = system.dispatchers.lookup(settings.ClientDispatcher)
 
     class DynamoDBClient(
         override val ec: ExecutionContext,
-        override val dynamoDB: AmazonDynamoDBAsync,
+        override val dynamoDB: DynamoDbAsyncClient,
         override val settings: DynamoDBConfig,
         override val scheduler: Scheduler,
         override val log: LoggingAdapter)

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/package.scala
@@ -40,6 +40,14 @@ package object dynamodb {
 
   def B(value: Array[Byte]): AttributeValue = AttributeValue.fromB(SdkBytes.fromByteArray(value))
 
+  /**
+   * A DynamoDB response only carries a `LastEvaluatedKey` when there are further pages to read.
+   * The AWS SDK models an absent key as an empty auto-constructed map, but an explicitly empty
+   * map is possible too, so both are treated as "no more pages".
+   */
+  private[dynamodb] def nonEmptyKey(key: Item): Option[Item] =
+    if (key == null || key.isEmpty) None else Some(key)
+
   def lift[T](f: Future[T]): Future[Try[T]] = {
     val p = Promise[Try[T]]()
     f.onComplete(p.success)(ExecutionContext.parasitic)
@@ -65,6 +73,7 @@ package object dynamodb {
     }.map(_.result())
 
   def dynamoClient(system: ActorSystem, settings: DynamoDBConfig): DynamoDBHelper = {
+    val log = Logging(system, "DynamoDBClient")
     val builder = DynamoDbAsyncClient.builder()
 
     if (settings.AwsKey.nonEmpty && settings.AwsSecret.nonEmpty) {
@@ -73,15 +82,25 @@ package object dynamodb {
     }
 
     if (settings.Region.nonEmpty) {
-      try {
-        builder.region(Region.of(settings.Region))
-      } catch {
-        case e: IllegalArgumentException =>
-          throw new IllegalArgumentException(
-            s"Invalid AWS region '${settings.Region}' in configuration. " +
-            "See https://docs.aws.amazon.com/general/latest/gr/rande.html for valid region identifiers.",
-            e)
+      // Region.of only rejects blank input - it happily accepts any other string - so an unknown
+      // identifier is reported here rather than surfacing later as an obscure signing or DNS failure.
+      val region =
+        try Region.of(settings.Region)
+        catch {
+          case e: IllegalArgumentException =>
+            throw new IllegalArgumentException(
+              s"Invalid AWS region '${settings.Region}' in configuration. " +
+              "See https://docs.aws.amazon.com/general/latest/gr/rande.html for valid region identifiers.",
+              e)
+        }
+      if (!Region.regions.contains(region)) {
+        // not fatal: a region added after this AWS SDK release will not be in the built-in list
+        log.warning(
+          "AWS region '{}' is not known to this version of the AWS SDK - check for a typo. " +
+          "See https://docs.aws.amazon.com/general/latest/gr/rande.html for valid region identifiers.",
+          settings.Region)
       }
+      builder.region(region)
     } else if (settings.Endpoint.nonEmpty) {
       // When using a custom endpoint (e.g. DynamoDB Local), SDK v2 requires a region for
       // request signing. Fall back to us-east-1 since the region is irrelevant for local endpoints.
@@ -103,7 +122,7 @@ package object dynamodb {
         override val log: LoggingAdapter)
         extends DynamoDBHelper
 
-    new DynamoDBClient(dispatcher, client, settings, system.scheduler, Logging(system, "DynamoDBClient"))
+    new DynamoDBClient(dispatcher, client, settings, system.scheduler, log)
   }
 
 }

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/DynamoDBReadJournalConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/DynamoDBReadJournalConfig.scala
@@ -20,6 +20,7 @@ class DynamoDBReadJournalConfig(c: Config) extends DynamoDBConfig {
   val AwsKey: String = c.getString("aws-access-key-id")
   val AwsSecret: String = c.getString("aws-secret-access-key")
   val Endpoint: String = c.getString("endpoint")
+  val Region: String = c.getString("region")
 
   val MaxBatchGet: Int = c.getInt("aws-api-limits.max-batch-get")
   val MaxBatchWrite: Int = c.getInt("aws-api-limits.max-batch-write")

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/DynamoDBReadJournalConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/DynamoDBReadJournalConfig.scala
@@ -11,7 +11,7 @@ package org.apache.pekko.persistence.dynamodb.query
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.persistence.dynamodb.query.scaladsl.DynamoDBReadJournal
-import org.apache.pekko.persistence.dynamodb.{ ClientConfig, DynamoDBClientConfig, DynamoDBConfig }
+import org.apache.pekko.persistence.dynamodb.DynamoDBConfig
 import com.typesafe.config.Config
 
 class DynamoDBReadJournalConfig(c: Config) extends DynamoDBConfig {
@@ -33,8 +33,6 @@ class DynamoDBReadJournalConfig(c: Config) extends DynamoDBConfig {
     "Table:" + Table +
     ",AwsKey:" + AwsKey +
     ",Endpoint:" + Endpoint + ")"
-
-  override val client: ClientConfig = new DynamoDBClientConfig(c)
 
   override val ClientDispatcher: String = c.getString("client-dispatcher")
   override val Tracing: Boolean = c.getBoolean("tracing")

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -15,7 +15,7 @@ import org.apache.pekko.persistence.dynamodb.query.ReadJournalSettingsProvider
 import org.apache.pekko.persistence.dynamodb.query.scaladsl.CreatePersistenceIdsIndex.createPersistenceIdsIndexRequest
 import org.apache.pekko.persistence.query.scaladsl.CurrentPersistenceIdsQuery
 import org.apache.pekko.stream.scaladsl.Source
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.concurrent.Future
 
@@ -59,7 +59,7 @@ trait CreatePersistenceIdsIndex {
    * Update the journal table to add the Global Secondary Index 'persistence-ids-idx' that's required by [[DynamoDBCurrentPersistenceIdsQuery.currentPersistenceIdsByPageQuery]]
    * @param alphabetically sort persistence ids
    */
-  def createPersistenceIdsIndex(alphabetically: Boolean = false): Future[UpdateTableResult] =
+  def createPersistenceIdsIndex(alphabetically: Boolean = false): Future[UpdateTableResponse] =
     dynamo.updateTable(
       createPersistenceIdsIndexRequest(
         indexName = readJournalSettings.PersistenceIdsIndexName,
@@ -81,21 +81,23 @@ object CreatePersistenceIdsIndex {
       indexName: String,
       tableName: String,
       alphabetically: Boolean = false): UpdateTableRequest = {
-    val createIndex = new CreateGlobalSecondaryIndexAction()
-      .withIndexName(indexName)
-      .withProjection(new Projection().withProjectionType(ProjectionType.KEYS_ONLY))
-      .withProvisionedThroughput(new ProvisionedThroughput().withReadCapacityUnits(10).withWriteCapacityUnits(10))
+    val createIndexBuilder = CreateGlobalSecondaryIndexAction.builder()
+      .indexName(indexName)
+      .projection(Projection.builder().projectionType(ProjectionType.KEYS_ONLY).build())
+      .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(10).writeCapacityUnits(10).build())
     if (alphabetically) {
-      createIndex.withKeySchema(
-        new KeySchemaElement().withAttributeName("num").withKeyType(KeyType.HASH),
-        new KeySchemaElement().withAttributeName("par").withKeyType(KeyType.RANGE))
+      createIndexBuilder.keySchema(
+        KeySchemaElement.builder().attributeName("num").keyType(KeyType.HASH).build(),
+        KeySchemaElement.builder().attributeName("par").keyType(KeyType.RANGE).build())
     } else {
-      createIndex.withKeySchema(new KeySchemaElement().withAttributeName("num").withKeyType(KeyType.HASH))
+      createIndexBuilder.keySchema(KeySchemaElement.builder().attributeName("num").keyType(KeyType.HASH).build())
     }
-    new UpdateTableRequest()
-      .withTableName(tableName)
-      .withGlobalSecondaryIndexUpdates(new GlobalSecondaryIndexUpdate().withCreate(createIndex))
-      .withAttributeDefinitions(new AttributeDefinition().withAttributeName("num").withAttributeType("N"))
+    UpdateTableRequest.builder()
+      .tableName(tableName)
+      .globalSecondaryIndexUpdates(GlobalSecondaryIndexUpdate.builder().create(createIndexBuilder.build()).build())
+      .attributeDefinitions(
+        AttributeDefinition.builder().attributeName("num").attributeType(ScalarAttributeType.N).build())
+      .build()
   }
 
   /** required by [[DynamoDBCurrentPersistenceIdsQuery.currentPersistenceIdsAlphabeticallyByPageQuery]] */

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -24,7 +24,7 @@ import org.apache.pekko.persistence.dynamodb.query.scaladsl.{
 import org.apache.pekko.persistence.dynamodb.query.{ ReadJournalSettingsProvider, RichOption }
 import org.apache.pekko.persistence.dynamodb.{ ActorSystemProvider, DynamoProvider, LoggingProvider }
 import org.apache.pekko.stream.scaladsl.Source
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 
 import java.util
 import scala.concurrent.Future
@@ -128,36 +128,35 @@ trait DynamoDBCurrentPersistenceIdsQuery extends PublicDynamoDBCurrentPersistenc
       exclusiveStartKey: Option[java.util.Map[String, AttributeValue]]) = {
 
     def queryRequest(exclusiveStartKey: Option[java.util.Map[String, AttributeValue]]): QueryRequest = {
-      val req = new QueryRequest()
-        .withTableName(readJournalSettings.Table)
-        .withIndexName(readJournalSettings.PersistenceIdsIndexName)
-        .withProjectionExpression("par")
+      val builder = QueryRequest.builder()
+        .tableName(readJournalSettings.Table)
+        .indexName(readJournalSettings.PersistenceIdsIndexName)
+        .projectionExpression("par")
 
       fromPersistenceId match {
         case Some(persistenceId) =>
-          req
-            .withKeyConditionExpression("num = :n AND par > :p")
-            .withExpressionAttributeValues(
+          builder
+            .keyConditionExpression("num = :n AND par > :p")
+            .expressionAttributeValues(
               Map(":n" -> 1.toAttribute, ":p" -> messagePartitionKeyFromGroupNr(persistenceId, 0).toAttribute).asJava)
         case None =>
-          req.withKeyConditionExpression("num = :n").withExpressionAttributeValues(Map(":n" -> 1.toAttribute).asJava)
-
+          builder.keyConditionExpression("num = :n").expressionAttributeValues(Map(":n" -> 1.toAttribute).asJava)
       }
-      exclusiveStartKey.foreach(esk => req.withExclusiveStartKey(esk))
-      req
+      exclusiveStartKey.foreach(esk => builder.exclusiveStartKey(esk))
+      builder.build()
     }
     dynamo.query(queryRequest(exclusiveStartKey))
   }
 
   private def scanPersistenceIds(exclusiveStartKey: Option[java.util.Map[String, AttributeValue]]) = {
     def scanRequest(exclusiveStartKey: Option[java.util.Map[String, AttributeValue]]): ScanRequest = {
-      val req = new ScanRequest()
-        .withTableName(readJournalSettings.Table)
-        .withProjectionExpression("par")
-        .withFilterExpression("num = :n")
-        .withExpressionAttributeValues(Map(":n" -> 1.toAttribute).asJava)
-      exclusiveStartKey.foreach(esk => req.withExclusiveStartKey(esk))
-      req
+      val builder = ScanRequest.builder()
+        .tableName(readJournalSettings.Table)
+        .projectionExpression("par")
+        .filterExpression("num = :n")
+        .expressionAttributeValues(Map(":n" -> 1.toAttribute).asJava)
+      exclusiveStartKey.foreach(esk => builder.exclusiveStartKey(esk))
+      builder.build()
     }
     dynamo.scan(scanRequest(exclusiveStartKey))
   }
@@ -186,11 +185,11 @@ trait DynamoDBCurrentPersistenceIdsQuery extends PublicDynamoDBCurrentPersistenc
 
 object DynamoDBCurrentPersistenceIdsQuery {
   implicit class RichString(val s: String) extends AnyVal {
-    def toAttribute: AttributeValue = new AttributeValue().withS(s)
+    def toAttribute: AttributeValue = AttributeValue.fromS(s)
   }
 
   implicit class RichNumber(val n: Int) extends AnyVal {
-    def toAttribute: AttributeValue = new AttributeValue().withN(n.toString)
+    def toAttribute: AttributeValue = AttributeValue.fromN(n.toString)
   }
 
   implicit class SourceLazyOps[E, M](val src: Source[E, M]) extends AnyVal {
@@ -202,7 +201,7 @@ object DynamoDBCurrentPersistenceIdsQuery {
   }
 }
 
-// The commonality between QueryResult and ScanResult which don't share an interface
+// The commonality between QueryResponse and ScanResponse which don't share an interface
 private[query] trait PersistenceIdsResult[A] {
   def toPersistenceIdsPage(result: A): Seq[String]
 
@@ -211,23 +210,25 @@ private[query] trait PersistenceIdsResult[A] {
 
 private[query] object PersistenceIdsResult {
 
-  implicit val persistenceIdsQueryResult: PersistenceIdsResult[QueryResult] = new PersistenceIdsResult[QueryResult] {
-    override def toPersistenceIdsPage(result: QueryResult): Seq[String] =
-      result.getItems.asScala.map(item => item.get("par").getS).toSeq
+  implicit val persistenceIdsQueryResult: PersistenceIdsResult[QueryResponse] =
+    new PersistenceIdsResult[QueryResponse] {
+      override def toPersistenceIdsPage(result: QueryResponse): Seq[String] =
+        result.items.asScala.map(item => item.get("par").s).toSeq
 
-    override def nextEvaluatedKey(result: QueryResult): Option[util.Map[String, AttributeValue]] =
-      if (result.getLastEvaluatedKey != null && !result.getLastEvaluatedKey.isEmpty) Some(result.getLastEvaluatedKey)
-      else None
-  }
+      override def nextEvaluatedKey(result: QueryResponse): Option[util.Map[String, AttributeValue]] =
+        if (result.hasLastEvaluatedKey && !result.lastEvaluatedKey.isEmpty) Some(result.lastEvaluatedKey)
+        else None
+    }
 
-  implicit val persistenceIdsScanResult: PersistenceIdsResult[ScanResult] = new PersistenceIdsResult[ScanResult] {
-    override def toPersistenceIdsPage(result: ScanResult): Seq[String] =
-      result.getItems.asScala.map(item => item.get("par").getS).toSeq
+  implicit val persistenceIdsScanResult: PersistenceIdsResult[ScanResponse] =
+    new PersistenceIdsResult[ScanResponse] {
+      override def toPersistenceIdsPage(result: ScanResponse): Seq[String] =
+        result.items.asScala.map(item => item.get("par").s).toSeq
 
-    override def nextEvaluatedKey(result: ScanResult): Option[util.Map[String, AttributeValue]] =
-      if (result.getLastEvaluatedKey != null && !result.getLastEvaluatedKey.isEmpty) Some(result.getLastEvaluatedKey)
-      else None
-  }
+      override def nextEvaluatedKey(result: ScanResponse): Option[util.Map[String, AttributeValue]] =
+        if (result.hasLastEvaluatedKey && !result.lastEvaluatedKey.isEmpty) Some(result.lastEvaluatedKey)
+        else None
+    }
 
   implicit class RichPersistenceIdsResult[Result](val result: Result) extends AnyVal {
     def toPersistenceIdsPage(implicit persistenceIdsResult: PersistenceIdsResult[Result]): Seq[String] =

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -22,7 +22,7 @@ import org.apache.pekko.persistence.dynamodb.query.scaladsl.{
   DynamoDBCurrentPersistenceIdsQuery => PublicDynamoDBCurrentPersistenceIdsQuery
 }
 import org.apache.pekko.persistence.dynamodb.query.{ ReadJournalSettingsProvider, RichOption }
-import org.apache.pekko.persistence.dynamodb.{ ActorSystemProvider, DynamoProvider, LoggingProvider }
+import org.apache.pekko.persistence.dynamodb.{ nonEmptyKey, ActorSystemProvider, DynamoProvider, LoggingProvider }
 import org.apache.pekko.stream.scaladsl.Source
 import software.amazon.awssdk.services.dynamodb.model._
 
@@ -216,8 +216,7 @@ private[query] object PersistenceIdsResult {
         result.items.asScala.map(item => item.get("par").s).toSeq
 
       override def nextEvaluatedKey(result: QueryResponse): Option[util.Map[String, AttributeValue]] =
-        if (result.hasLastEvaluatedKey) Some(result.lastEvaluatedKey)
-        else None
+        nonEmptyKey(result.lastEvaluatedKey)
     }
 
   implicit val persistenceIdsScanResult: PersistenceIdsResult[ScanResponse] =
@@ -226,8 +225,7 @@ private[query] object PersistenceIdsResult {
         result.items.asScala.map(item => item.get("par").s).toSeq
 
       override def nextEvaluatedKey(result: ScanResponse): Option[util.Map[String, AttributeValue]] =
-        if (result.hasLastEvaluatedKey) Some(result.lastEvaluatedKey)
-        else None
+        nonEmptyKey(result.lastEvaluatedKey)
     }
 
   implicit class RichPersistenceIdsResult[Result](val result: Result) extends AnyVal {

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/query/scaladsl/internal/DynamoDBCurrentPersistenceIdsQuery.scala
@@ -216,7 +216,7 @@ private[query] object PersistenceIdsResult {
         result.items.asScala.map(item => item.get("par").s).toSeq
 
       override def nextEvaluatedKey(result: QueryResponse): Option[util.Map[String, AttributeValue]] =
-        if (result.hasLastEvaluatedKey && !result.lastEvaluatedKey.isEmpty) Some(result.lastEvaluatedKey)
+        if (result.hasLastEvaluatedKey) Some(result.lastEvaluatedKey)
         else None
     }
 
@@ -226,7 +226,7 @@ private[query] object PersistenceIdsResult {
         result.items.asScala.map(item => item.get("par").s).toSeq
 
       override def nextEvaluatedKey(result: ScanResponse): Option[util.Map[String, AttributeValue]] =
-        if (result.hasLastEvaluatedKey && !result.lastEvaluatedKey.isEmpty) Some(result.lastEvaluatedKey)
+        if (result.hasLastEvaluatedKey) Some(result.lastEvaluatedKey)
         else None
     }
 

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotConfig.scala
@@ -22,6 +22,7 @@ class DynamoDBSnapshotConfig(c: Config) extends DynamoDBConfig {
   val AwsKey = c.getString("aws-access-key-id")
   val AwsSecret = c.getString("aws-secret-access-key")
   val Endpoint = c.getString("endpoint")
+  val Region = c.getString("region")
 
   val MaxBatchGet = c.getInt("aws-api-limits.max-batch-get")
   val MaxBatchWrite = c.getInt("aws-api-limits.max-batch-write")

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotConfig.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotConfig.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.persistence.dynamodb.snapshot
 
-import org.apache.pekko.persistence.dynamodb.{ ClientConfig, DynamoDBClientConfig, DynamoDBConfig }
+import org.apache.pekko.persistence.dynamodb.DynamoDBConfig
 import com.typesafe.config.Config
 
 class DynamoDBSnapshotConfig(c: Config) extends DynamoDBConfig {
@@ -29,12 +29,10 @@ class DynamoDBSnapshotConfig(c: Config) extends DynamoDBConfig {
   val MaxItemSize = c.getInt("aws-api-limits.max-item-size")
 
   override def toString: String =
-    "DynamoDBJournalConfig(" +
+    "DynamoDBSnapshotConfig(" +
     "SnapshotTable:" + Table +
     ",AwsKey:" + AwsKey +
     ",Endpoint:" + Endpoint + ")"
-
-  override val client: ClientConfig = new DynamoDBClientConfig(c)
 
   override val ClientDispatcher = c.getString("client-dispatcher")
   override val Tracing = c.getBoolean("tracing")

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotRequests.scala
@@ -13,8 +13,7 @@
 
 package org.apache.pekko.persistence.dynamodb.snapshot
 
-import com.amazonaws.services.dynamodbv2.model._
-import com.amazonaws.services.dynamodbv2.model.Select.ALL_ATTRIBUTES
+import software.amazon.awssdk.services.dynamodb.model._
 import org.apache.pekko
 import pekko.actor.ExtendedActorSystem
 import pekko.persistence.dynamodb._
@@ -38,28 +37,28 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
     DynamoFixedByteSize + partitionKey.length + serializedSnapshot.size
 
   def delete(metadata: SnapshotMetadata): Future[Unit] = {
-    val request = new DeleteItemRequest()
-      .withTableName(Table)
-      .addKeyEntry(Key, S(messagePartitionKey(metadata.persistenceId)))
-      .addKeyEntry(SequenceNr, N(metadata.sequenceNr))
+    val request = DeleteItemRequest.builder()
+      .tableName(Table)
+      .key(Map(
+        Key -> S(messagePartitionKey(metadata.persistenceId)),
+        SequenceNr -> N(metadata.sequenceNr)).asJava)
+      .build()
 
     dynamo.deleteItem(request).map(toUnit)
   }
 
   def delete(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = {
     loadQueryResult(persistenceId, criteria).flatMap { queryResult =>
-      val result = queryResult.getItems.asScala.toSeq.map(item => item.get(SequenceNr).getN.toLong)
+      val result = queryResult.items.asScala.toSeq.map(item => item.get(SequenceNr).n.toLong)
       doBatch(batch => s"execute batch delete $batch", result.map(snapshotDeleteReq(persistenceId, _))).map(toUnit)
     }
   }
 
   private def snapshotDeleteReq(persistenceId: String, sequenceNr: Long): WriteRequest = {
-    new WriteRequest().withDeleteRequest(new DeleteRequest().withKey {
-      val item: Item = new JHMap
-      item.put(Key, S(messagePartitionKey(persistenceId)))
-      item.put(SequenceNr, N(sequenceNr))
-      item
-    })
+    WriteRequest.builder().deleteRequest(
+      DeleteRequest.builder().key(Map(
+        Key -> S(messagePartitionKey(persistenceId)),
+        SequenceNr -> N(sequenceNr)).asJava).build()).build()
   }
 
   def save(persistenceId: String, sequenceNr: Long, timestamp: Long, snapshot: Any): Future[Unit] = {
@@ -71,7 +70,7 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
   def load(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
 
     loadQueryResult(persistenceId, criteria, Some(1)).flatMap { result =>
-      result.getItems.asScala.headOption match {
+      result.items.asScala.headOption match {
         case Some(youngest) => fromSnapshotItem(persistenceId, youngest).map(Some(_))
         case None           => Future.successful(None)
       }
@@ -81,7 +80,7 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
   private def loadQueryResult(
       persistenceId: String,
       criteria: SnapshotSelectionCriteria,
-      limit: Option[Int] = None): Future[QueryResult] = {
+      limit: Option[Int] = None): Future[QueryResponse] = {
     criteria match {
       case SnapshotSelectionCriteria(maxSequenceNr, maxTimestamp, minSequenceNr, minTimestamp)
           if minSequenceNr == 0 && maxSequenceNr == Long.MaxValue =>
@@ -99,59 +98,61 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
       persistenceId: String,
       minTimestamp: Long,
       maxTimestamp: Long,
-      limit: Option[Int]): Future[QueryResult] = {
-    val request = new QueryRequest()
-      .withTableName(Table)
-      .withIndexName(TimestampIndex)
-      .withKeyConditionExpression(s" $Key = :partitionKeyVal AND $Timestamp BETWEEN :tsMinVal AND :tsMaxVal ")
-      .addExpressionAttributeValuesEntry(":partitionKeyVal", S(messagePartitionKey(persistenceId)))
-      .addExpressionAttributeValuesEntry(":tsMinVal", N(minTimestamp))
-      .addExpressionAttributeValuesEntry(":tsMaxVal", N(maxTimestamp))
-      .withScanIndexForward(false)
-      .withConsistentRead(true)
-    limit.foreach(request.setLimit(_))
+      limit: Option[Int]): Future[QueryResponse] = {
+    val builder = QueryRequest.builder()
+      .tableName(Table)
+      .indexName(TimestampIndex)
+      .keyConditionExpression(s" $Key = :partitionKeyVal AND $Timestamp BETWEEN :tsMinVal AND :tsMaxVal ")
+      .expressionAttributeValues(Map(
+        ":partitionKeyVal" -> S(messagePartitionKey(persistenceId)),
+        ":tsMinVal" -> N(minTimestamp),
+        ":tsMaxVal" -> N(maxTimestamp)).asJava)
+      .scanIndexForward(false)
+      .consistentRead(true)
+      .select(Select.ALL_ATTRIBUTES)
+    limit.foreach(l => builder.limit(l))
 
-    request.setSelect(ALL_ATTRIBUTES)
-
-    dynamo.query(request)
+    dynamo.query(builder.build())
   }
 
   private def loadBySeqNr(
       persistenceId: String,
       minSequenceNr: Long,
       maxSequenceNr: Long,
-      limit: Option[Int]): Future[QueryResult] = {
-    val request = new QueryRequest()
-      .withTableName(Table)
-      .withKeyConditionExpression(s" $Key = :partitionKeyVal AND $SequenceNr BETWEEN :seqMinVal AND :seqMaxVal")
-      .addExpressionAttributeValuesEntry(":partitionKeyVal", S(messagePartitionKey(persistenceId)))
-      .addExpressionAttributeValuesEntry(":seqMinVal", N(minSequenceNr))
-      .addExpressionAttributeValuesEntry(":seqMaxVal", N(maxSequenceNr))
-      .withScanIndexForward(false)
-      .withConsistentRead(true)
-    limit.foreach(request.setLimit(_))
+      limit: Option[Int]): Future[QueryResponse] = {
+    val builder = QueryRequest.builder()
+      .tableName(Table)
+      .keyConditionExpression(s" $Key = :partitionKeyVal AND $SequenceNr BETWEEN :seqMinVal AND :seqMaxVal")
+      .expressionAttributeValues(Map(
+        ":partitionKeyVal" -> S(messagePartitionKey(persistenceId)),
+        ":seqMinVal" -> N(minSequenceNr),
+        ":seqMaxVal" -> N(maxSequenceNr)).asJava)
+      .scanIndexForward(false)
+      .consistentRead(true)
+    limit.foreach(l => builder.limit(l))
 
-    dynamo.query(request)
+    dynamo.query(builder.build())
   }
 
   private def loadByBoth(
       persistenceId: String,
       criteria: SnapshotSelectionCriteria,
-      limit: Option[Int]): Future[QueryResult] = {
-    val request = new QueryRequest()
-      .withTableName(Table)
-      .withKeyConditionExpression(s" $Key = :partitionKeyVal AND $SequenceNr BETWEEN :seqMinVal AND :seqMaxVal")
-      .addExpressionAttributeValuesEntry(":partitionKeyVal", S(messagePartitionKey(persistenceId)))
-      .addExpressionAttributeValuesEntry(":seqMinVal", N(criteria.minSequenceNr))
-      .addExpressionAttributeValuesEntry(":seqMaxVal", N(criteria.maxSequenceNr))
-      .withScanIndexForward(false)
-      .withFilterExpression(s"$Timestamp BETWEEN :tsMinVal AND :tsMaxVal ")
-      .addExpressionAttributeValuesEntry(":tsMinVal", N(criteria.minTimestamp))
-      .addExpressionAttributeValuesEntry(":tsMaxVal", N(criteria.maxTimestamp))
-      .withConsistentRead(true)
-    limit.foreach(request.setLimit(_))
+      limit: Option[Int]): Future[QueryResponse] = {
+    val builder = QueryRequest.builder()
+      .tableName(Table)
+      .keyConditionExpression(s" $Key = :partitionKeyVal AND $SequenceNr BETWEEN :seqMinVal AND :seqMaxVal")
+      .expressionAttributeValues(Map(
+        ":partitionKeyVal" -> S(messagePartitionKey(persistenceId)),
+        ":seqMinVal" -> N(criteria.minSequenceNr),
+        ":seqMaxVal" -> N(criteria.maxSequenceNr),
+        ":tsMinVal" -> N(criteria.minTimestamp),
+        ":tsMaxVal" -> N(criteria.maxTimestamp)).asJava)
+      .scanIndexForward(false)
+      .filterExpression(s"$Timestamp BETWEEN :tsMinVal AND :tsMaxVal ")
+      .consistentRead(true)
+    limit.foreach(l => builder.limit(l))
 
-    dynamo.query(request)
+    dynamo.query(builder.build())
   }
 
   private def toSnapshotItem(persistenceId: String, sequenceNr: Long, timestamp: Long, snapshot: Any): Future[Item] = {
@@ -193,22 +194,22 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
   }
 
   private def fromSnapshotItem(persistenceId: String, item: Item): Future[SelectedSnapshot] = {
-    val seqNr = item.get(SequenceNr).getN.toLong
-    val timestamp = item.get(Timestamp).getN.toLong
+    val seqNr = item.get(SequenceNr).n.toLong
+    val timestamp = item.get(Timestamp).n.toLong
 
     if (item.containsKey(PayloadData)) {
 
-      val payloadData = item.get(PayloadData).getB
-      val serId = item.get(SerializerId).getN.toInt
-      val manifest = if (item.containsKey(SerializerManifest)) item.get(SerializerManifest).getS else ""
+      val payloadData = item.get(PayloadData).b
+      val serId = item.get(SerializerId).n.toInt
+      val manifest = if (item.containsKey(SerializerManifest)) item.get(SerializerManifest).s else ""
 
       val serialized = serialization.serializerByIdentity(serId) match {
         case aS: AsyncSerializer =>
           Serialization.withTransportInformation(context.system.asInstanceOf[ExtendedActorSystem]) { () =>
-            aS.fromBinaryAsync(payloadData.array(), manifest)
+            aS.fromBinaryAsync(payloadData.asByteArray(), manifest)
           }
         case _ =>
-          Future.successful(serialization.deserialize(payloadData.array(), serId, manifest).get)
+          Future.successful(serialization.deserialize(payloadData.asByteArray(), serId, manifest).get)
       }
 
       serialized.map(data =>
@@ -217,11 +218,11 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
           snapshot = data))
 
     } else {
-      val payloadValue = item.get(Payload).getB
+      val payloadValue = item.get(Payload).b
       Future.successful(
         SelectedSnapshot(
           metadata = SnapshotMetadata(persistenceId, sequenceNr = seqNr, timestamp = timestamp),
-          snapshot = serialization.deserialize(payloadValue.array(), classOf[Snapshot]).get.data))
+          snapshot = serialization.deserialize(payloadValue.asByteArray(), classOf[Snapshot]).get.data))
     }
   }
 

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotRequests.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBSnapshotRequests.scala
@@ -199,6 +199,8 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
 
     if (item.containsKey(PayloadData)) {
 
+      // asByteArrayUnsafe avoids copying the payload: deserialization only reads the array,
+      // and the response it belongs to is discarded once the snapshot has been read
       val payloadData = item.get(PayloadData).b
       val serId = item.get(SerializerId).n.toInt
       val manifest = if (item.containsKey(SerializerManifest)) item.get(SerializerManifest).s else ""
@@ -206,10 +208,10 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
       val serialized = serialization.serializerByIdentity(serId) match {
         case aS: AsyncSerializer =>
           Serialization.withTransportInformation(context.system.asInstanceOf[ExtendedActorSystem]) { () =>
-            aS.fromBinaryAsync(payloadData.asByteArray(), manifest)
+            aS.fromBinaryAsync(payloadData.asByteArrayUnsafe(), manifest)
           }
         case _ =>
-          Future.successful(serialization.deserialize(payloadData.asByteArray(), serId, manifest).get)
+          Future.successful(serialization.deserialize(payloadData.asByteArrayUnsafe(), serId, manifest).get)
       }
 
       serialized.map(data =>
@@ -222,7 +224,7 @@ trait DynamoDBSnapshotRequests extends DynamoDBRequests {
       Future.successful(
         SelectedSnapshot(
           metadata = SnapshotMetadata(persistenceId, sequenceNr = seqNr, timestamp = timestamp),
-          snapshot = serialization.deserialize(payloadValue.asByteArray(), classOf[Snapshot]).get.data))
+          snapshot = serialization.deserialize(payloadValue.asByteArrayUnsafe(), classOf[Snapshot]).get.data))
     }
   }
 

--- a/src/test/scala-2/org/apache/pekko/persistence/dynamodb/journal/WriteThroughputBench.scala
+++ b/src/test/scala-2/org/apache/pekko/persistence/dynamodb/journal/WriteThroughputBench.scala
@@ -39,9 +39,6 @@ my-dynamodb-journal {
   endpoint = ${?AWS_DYNAMODB_ENDPOINT}
   aws-access-key-id = ${?AWS_ACCESS_KEY_ID}
   aws-secret-access-key = ${?AWS_SECRET_ACCESS_KEY}
-  aws-client-config {
-    max-connections = 100
-  }
   plugin-dispatcher = "dispatcher"
   replay-dispatcher = "dispatcher"
   client-dispatcher = "dispatcher"

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
@@ -20,6 +20,7 @@ import org.apache.pekko.persistence.dynamodb.IntegSpec
 import org.apache.pekko.testkit._
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.{ AttributeValue, PutItemRequest }
 import com.typesafe.config.ConfigFactory
@@ -54,6 +55,7 @@ class BackwardsCompatibilityV1Spec
     val client: DynamoDbClient = DynamoDbClient.builder()
       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
       .endpointOverride(URI.create(endpoint))
+      .region(Region.US_EAST_1)
       .build()
 
     val persistenceId = "journal-P-OldFormatEvents-0"

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/BackwardsCompatibilityV1Spec.scala
@@ -18,10 +18,10 @@ import org.apache.pekko.persistence.JournalProtocol._
 import org.apache.pekko.persistence._
 import org.apache.pekko.persistence.dynamodb.IntegSpec
 import org.apache.pekko.testkit._
-import com.amazonaws.auth.{ AWSStaticCredentialsProvider, BasicAWSCredentials }
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.dynamodbv2.document.{ DynamoDB, Item }
-import com.amazonaws.services.dynamodbv2.{ AmazonDynamoDB, AmazonDynamoDBClientBuilder }
+import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{ AttributeValue, PutItemRequest }
 import com.typesafe.config.ConfigFactory
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.BeforeAndAfterAll
@@ -29,7 +29,9 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import java.net.URI
 import java.util.Base64
+import scala.jdk.CollectionConverters._
 
 class BackwardsCompatibilityV1Spec
     extends TestKit(ActorSystem("BackwardsCompatibilityV1Spec"))
@@ -46,16 +48,13 @@ class BackwardsCompatibilityV1Spec
     val config = ConfigFactory.load()
     val endpoint = config.getString("my-dynamodb-journal.endpoint")
     val tableName = config.getString("my-dynamodb-journal.journal-table")
-    val accesKey = config.getString("my-dynamodb-journal.aws-access-key-id")
+    val accessKey = config.getString("my-dynamodb-journal.aws-access-key-id")
     val secretKey = config.getString("my-dynamodb-journal.aws-secret-access-key")
 
-    val client: AmazonDynamoDB =
-      AmazonDynamoDBClientBuilder.standard()
-        .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accesKey, secretKey)))
-        .withEndpointConfiguration(new EndpointConfiguration(endpoint, "us-east-1"))
-        .build()
-
-    val dynamoDB = new DynamoDB(client)
+    val client: DynamoDbClient = DynamoDbClient.builder()
+      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+      .endpointOverride(URI.create(endpoint))
+      .build()
 
     val persistenceId = "journal-P-OldFormatEvents-0"
 
@@ -81,13 +80,12 @@ class BackwardsCompatibilityV1Spec
       "ChEIARINrO0ABXQABmEtMDAxORATGg9PbGRGb3JtYXRFdmVudHNqJDI5NWZhMTE2LWZhOTUtNGY1Yi1hZjk2LTgwZDk4NjFhODk4ZA==",
       "ChEIARINrO0ABXQABmEtMDAyMBAUGg9PbGRGb3JtYXRFdmVudHNqJDI5NWZhMTE2LWZhOTUtNGY1Yi1hZjk2LTgwZDk4NjFhODk4ZA==")
 
-    val table = dynamoDB.getTable(tableName)
-
     def createItem(number: Int, data: String): Unit = {
-      table.putItem(
-        new Item()
-          .withPrimaryKey("par", persistenceId, "num", number)
-          .withBinary("pay", Base64.getDecoder.decode(data)))
+      val item = Map(
+        "par" -> AttributeValue.fromS(persistenceId),
+        "num" -> AttributeValue.fromN(number.toString),
+        "pay" -> AttributeValue.fromB(SdkBytes.fromByteArray(Base64.getDecoder.decode(data)))).asJava
+      client.putItem(PutItemRequest.builder().tableName(tableName).item(item).build())
     }
 
     for {
@@ -95,6 +93,7 @@ class BackwardsCompatibilityV1Spec
       payload = messagePayloads(i)
     } yield createItem(i + 1, payload)
 
+    client.close()
   }
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBUtils.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBUtils.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.persistence.dynamodb.journal
 
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.persistence.PersistentRepr
@@ -42,20 +42,21 @@ trait DynamoDBUtils extends JournalSettingsProvider with DynamoProvider {
   def ensureJournalTableExists(read: Long = 10L, write: Long = 10L): Unit = {
     val create =
       schema
-        .withTableName(journalSettings.JournalTable)
-        .withProvisionedThroughput(new ProvisionedThroughput(read, write))
+        .tableName(journalSettings.JournalTable)
+        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(read).writeCapacityUnits(write).build())
+        .build()
     implicit val dispatcher = system.dispatcher
 
     var names = Vector.empty[String]
-    lazy val complete: ListTablesResult => Future[Vector[String]] = aws =>
-      if (aws.getLastEvaluatedTableName == null) Future.successful(names ++ aws.getTableNames.asScala)
+    lazy val complete: ListTablesResponse => Future[Vector[String]] = aws =>
+      if (aws.lastEvaluatedTableName == null) Future.successful(names ++ aws.tableNames.asScala)
       else {
-        names ++= aws.getTableNames.asScala
+        names ++= aws.tableNames.asScala
         dynamo
-          .listTables(new ListTablesRequest().withExclusiveStartTableName(aws.getLastEvaluatedTableName))
+          .listTables(ListTablesRequest.builder().exclusiveStartTableName(aws.lastEvaluatedTableName).build())
           .flatMap(complete)
       }
-    val list = dynamo.listTables(new ListTablesRequest).flatMap(complete)
+    val list = dynamo.listTables(ListTablesRequest.builder().build()).flatMap(complete)
 
     val setup = for {
       exists <- list.map(_ contains journalSettings.JournalTable)

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBUtils.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBUtils.scala
@@ -43,7 +43,8 @@ trait DynamoDBUtils extends JournalSettingsProvider with DynamoProvider {
     val create =
       schema
         .tableName(journalSettings.JournalTable)
-        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(read).writeCapacityUnits(write).build())
+        .provisionedThroughput(
+          ProvisionedThroughput.builder().readCapacityUnits(read).writeCapacityUnits(write).build())
         .build()
     implicit val dispatcher = system.dispatcher
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -55,7 +55,7 @@ class FailureReportingSpec
     (rej.cause.getMessage should include).regex(msg)
   }
 
-  def expectFailure[T: Manifest](msg: String, repr: PersistentRepr) = {
+  def expectFailure[T: scala.reflect.ClassTag](msg: String, repr: PersistentRepr) = {
     val rej = expectMsgType[WriteMessageFailure]
     rej.message should ===(repr)
     rej.cause shouldBe a[T]

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -209,24 +209,25 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
 
       "reporting table problems" in {
         val aws = DescribeTableRequest.builder().tableName("TheTable").build()
-        dynamo.describeTable(aws).failed.futureValue.getMessage should (include("DescribeTable") or include("TheTable"))
+        dynamo.describeTable(aws).failed.futureValue.getMessage should
+        (include("DescribeTable").or(include("TheTable")))
       }
 
       "reporting putItem problems" in {
         val aws = PutItemRequest.builder().tableName("TheTable").item(keyItem).build()
-        dynamo.putItem(aws).failed.futureValue.getMessage should (include("PutItem") or include("TheTable"))
+        dynamo.putItem(aws).failed.futureValue.getMessage should (include("PutItem").or(include("TheTable")))
       }
 
       "reporting deleteItem problems" in {
         val aws = DeleteItemRequest.builder().tableName("TheTable").key(keyItem).build()
-        dynamo.deleteItem(aws).failed.futureValue.getMessage should (include("DeleteItem") or include("TheTable"))
+        dynamo.deleteItem(aws).failed.futureValue.getMessage should (include("DeleteItem").or(include("TheTable")))
       }
 
       "reporting query problems" in {
         val aws = QueryRequest.builder().tableName("TheTable")
           .keyConditionExpression(":kkey = par")
           .expressionAttributeValues(Map(":kkey" -> S("TheKey")).asJava).build()
-        dynamo.query(aws).failed.futureValue.getMessage should (include("Query") or include("TheTable"))
+        dynamo.query(aws).failed.futureValue.getMessage should (include("Query").or(include("TheTable")))
       }
 
       "reporting batch write problems" in {
@@ -234,13 +235,14 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
         val remove = WriteRequest.builder().deleteRequest(DeleteRequest.builder().key(key2Item).build()).build()
         val aws = BatchWriteItemRequest.builder()
           .requestItems(Map("TheTable" -> Seq(write, remove).asJava).asJava).build()
-        dynamo.batchWriteItem(aws).failed.futureValue.getMessage should (include("BatchWriteItem") or include("TheTable"))
+        dynamo.batchWriteItem(aws).failed.futureValue.getMessage should
+        (include("BatchWriteItem").or(include("TheTable")))
       }
 
       "reporting batch read problems" in {
         val ka = KeysAndAttributes.builder().keys(keyItem, key2Item).build()
         val aws = BatchGetItemRequest.builder().requestItems(Map("TheTable" -> ka).asJava).build()
-        dynamo.batchGetItem(aws).failed.futureValue.getMessage should (include("BatchGetItem") or include("TheTable"))
+        dynamo.batchGetItem(aws).failed.futureValue.getMessage should (include("BatchGetItem").or(include("TheTable")))
       }
     }
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -20,7 +20,7 @@ import pekko.persistence.JournalProtocol._
 import pekko.persistence._
 import pekko.persistence.dynamodb._
 import pekko.testkit._
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import com.typesafe.config.ConfigFactory
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.BeforeAndAfterAll
@@ -55,7 +55,7 @@ class FailureReportingSpec
     (rej.cause.getMessage should include).regex(msg)
   }
 
-  def expectFailure[T: scala.reflect.ClassTag](msg: String, repr: PersistentRepr) = {
+  def expectFailure[T: Manifest](msg: String, repr: PersistentRepr) = {
     val rej = expectMsgType[WriteMessageFailure]
     rej.message should ===(repr)
     rej.cause shouldBe a[T]
@@ -111,10 +111,10 @@ class FailureReportingSpec
 
     "notify user about used config" in {
       val config = ConfigFactory
-        .parseString("my-dynamodb-journal{log-config=on\naws-client-config.protocol=HTTPS}")
+        .parseString("my-dynamodb-journal{log-config=on}")
         .withFallback(ConfigFactory.load())
       implicit val system = ActorSystem("FailureReportingSpec-test3", config)
-      try EventFilter.info(pattern = ".*protocol:https.*", occurrences = 1).intercept {
+      try EventFilter.info(pattern = ".*DynamoDBJournalConfig.*", occurrences = 1).intercept {
           Persistence(system).journalFor("")
         }
       finally system.terminate()
@@ -204,62 +204,43 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
     }
 
     "have sensible error messages" when {
-      val evaluatedDynamo = dynamo
-      import evaluatedDynamo._
-      def desc[T](aws: T)(implicit d: Describe[? >: T]): String = d.desc(aws)
-
       val keyItem = Map(Key -> S("TheKey"), Sort -> N("42")).asJava
       val key2Item = Map(Key -> S("The2Key"), Sort -> N("43")).asJava
 
       "reporting table problems" in {
-        val aws = new DescribeTableRequest().withTableName("TheTable")
-        desc(aws) should include("DescribeTable")
-        desc(aws) should include("TheTable")
+        val aws = DescribeTableRequest.builder().tableName("TheTable").build()
+        dynamo.describeTable(aws).failed.futureValue.getMessage should (include("DescribeTable") or include("TheTable"))
       }
 
       "reporting putItem problems" in {
-        val aws = new PutItemRequest().withTableName("TheTable").withItem(keyItem)
-        desc(aws) should include("PutItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
-        desc(aws) should include("42")
+        val aws = PutItemRequest.builder().tableName("TheTable").item(keyItem).build()
+        dynamo.putItem(aws).failed.futureValue.getMessage should (include("PutItem") or include("TheTable"))
       }
 
       "reporting deleteItem problems" in {
-        val aws = new DeleteItemRequest().withTableName("TheTable").withKey(keyItem)
-        desc(aws) should include("DeleteItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
-        desc(aws) should include("42")
+        val aws = DeleteItemRequest.builder().tableName("TheTable").key(keyItem).build()
+        dynamo.deleteItem(aws).failed.futureValue.getMessage should (include("DeleteItem") or include("TheTable"))
       }
 
       "reporting query problems" in {
-        val aws =
-          new QueryRequest().withTableName("TheTable").withExpressionAttributeValues(Map(":kkey" -> S("TheKey")).asJava)
-        desc(aws) should include("Query")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
+        val aws = QueryRequest.builder().tableName("TheTable")
+          .keyConditionExpression(":kkey = par")
+          .expressionAttributeValues(Map(":kkey" -> S("TheKey")).asJava).build()
+        dynamo.query(aws).failed.futureValue.getMessage should (include("Query") or include("TheTable"))
       }
 
       "reporting batch write problems" in {
-        val write = new WriteRequest().withPutRequest(new PutRequest().withItem(keyItem))
-        val remove = new WriteRequest().withDeleteRequest(new DeleteRequest().withKey(key2Item))
-        val aws = new BatchWriteItemRequest().withRequestItems(Map("TheTable" -> Seq(write, remove).asJava).asJava)
-        desc(aws) should include("BatchWriteItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("put[par=TheKey,num=42]")
-        desc(aws) should include("del[par=The2Key,num=43]")
+        val write = WriteRequest.builder().putRequest(PutRequest.builder().item(keyItem).build()).build()
+        val remove = WriteRequest.builder().deleteRequest(DeleteRequest.builder().key(key2Item).build()).build()
+        val aws = BatchWriteItemRequest.builder()
+          .requestItems(Map("TheTable" -> Seq(write, remove).asJava).asJava).build()
+        dynamo.batchWriteItem(aws).failed.futureValue.getMessage should (include("BatchWriteItem") or include("TheTable"))
       }
 
       "reporting batch read problems" in {
-        val ka = new KeysAndAttributes().withKeys(keyItem, key2Item)
-        val aws = new BatchGetItemRequest().withRequestItems(Map("TheTable" -> ka).asJava)
-        desc(aws) should include("BatchGetItem")
-        desc(aws) should include("TheTable")
-        desc(aws) should include("TheKey")
-        desc(aws) should include("42")
-        desc(aws) should include("The2Key")
-        desc(aws) should include("43")
+        val ka = KeysAndAttributes.builder().keys(keyItem, key2Item).build()
+        val aws = BatchGetItemRequest.builder().requestItems(Map("TheTable" -> ka).asJava).build()
+        dynamo.batchGetItem(aws).failed.futureValue.getMessage should (include("BatchGetItem") or include("TheTable"))
       }
     }
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -210,24 +210,24 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
       "reporting table problems" in {
         val aws = DescribeTableRequest.builder().tableName("TheTable").build()
         dynamo.describeTable(aws).failed.futureValue.getMessage should
-        (include("DescribeTable").or(include("TheTable")))
+        (include("DescribeTable").and(include("TheTable")))
       }
 
       "reporting putItem problems" in {
         val aws = PutItemRequest.builder().tableName("TheTable").item(keyItem).build()
-        dynamo.putItem(aws).failed.futureValue.getMessage should (include("PutItem").or(include("TheTable")))
+        dynamo.putItem(aws).failed.futureValue.getMessage should (include("PutItem").and(include("TheTable")))
       }
 
       "reporting deleteItem problems" in {
         val aws = DeleteItemRequest.builder().tableName("TheTable").key(keyItem).build()
-        dynamo.deleteItem(aws).failed.futureValue.getMessage should (include("DeleteItem").or(include("TheTable")))
+        dynamo.deleteItem(aws).failed.futureValue.getMessage should (include("DeleteItem").and(include("TheTable")))
       }
 
       "reporting query problems" in {
         val aws = QueryRequest.builder().tableName("TheTable")
           .keyConditionExpression(":kkey = par")
           .expressionAttributeValues(Map(":kkey" -> S("TheKey")).asJava).build()
-        dynamo.query(aws).failed.futureValue.getMessage should (include("Query").or(include("TheTable")))
+        dynamo.query(aws).failed.futureValue.getMessage should (include("Query").and(include("TheTable")))
       }
 
       "reporting batch write problems" in {
@@ -236,13 +236,13 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
         val aws = BatchWriteItemRequest.builder()
           .requestItems(Map("TheTable" -> Seq(write, remove).asJava).asJava).build()
         dynamo.batchWriteItem(aws).failed.futureValue.getMessage should
-        (include("BatchWriteItem").or(include("TheTable")))
+        (include("BatchWriteItem").and(include("TheTable")))
       }
 
       "reporting batch read problems" in {
         val ka = KeysAndAttributes.builder().keys(keyItem, key2Item).build()
         val aws = BatchGetItemRequest.builder().requestItems(Map("TheTable" -> ka).asJava).build()
-        dynamo.batchGetItem(aws).failed.futureValue.getMessage should (include("BatchGetItem").or(include("TheTable")))
+        dynamo.batchGetItem(aws).failed.futureValue.getMessage should (include("BatchGetItem").and(include("TheTable")))
       }
     }
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/FailureReportingSpec.scala
@@ -28,6 +28,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
@@ -207,27 +208,43 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
       val keyItem = Map(Key -> S("TheKey"), Sort -> N("42")).asJava
       val key2Item = Map(Key -> S("The2Key"), Sort -> N("43")).asJava
 
+      // "TheTable" does not exist, so each request fails and the failure message is the request
+      // description that DynamoDBHelper builds - including the formatted keys.
+      def failureMessage(f: Future[?]): String = f.failed.futureValue.getMessage
+
       "reporting table problems" in {
         val aws = DescribeTableRequest.builder().tableName("TheTable").build()
-        dynamo.describeTable(aws).failed.futureValue.getMessage should
-        (include("DescribeTable").and(include("TheTable")))
+        val msg = failureMessage(dynamo.describeTable(aws))
+        msg should include("DescribeTable")
+        msg should include("TheTable")
       }
 
       "reporting putItem problems" in {
         val aws = PutItemRequest.builder().tableName("TheTable").item(keyItem).build()
-        dynamo.putItem(aws).failed.futureValue.getMessage should (include("PutItem").and(include("TheTable")))
+        val msg = failureMessage(dynamo.putItem(aws))
+        msg should include("PutItem")
+        msg should include("TheTable")
+        msg should include("TheKey")
+        msg should include("42")
       }
 
       "reporting deleteItem problems" in {
         val aws = DeleteItemRequest.builder().tableName("TheTable").key(keyItem).build()
-        dynamo.deleteItem(aws).failed.futureValue.getMessage should (include("DeleteItem").and(include("TheTable")))
+        val msg = failureMessage(dynamo.deleteItem(aws))
+        msg should include("DeleteItem")
+        msg should include("TheTable")
+        msg should include("TheKey")
+        msg should include("42")
       }
 
       "reporting query problems" in {
         val aws = QueryRequest.builder().tableName("TheTable")
           .keyConditionExpression(":kkey = par")
           .expressionAttributeValues(Map(":kkey" -> S("TheKey")).asJava).build()
-        dynamo.query(aws).failed.futureValue.getMessage should (include("Query").and(include("TheTable")))
+        val msg = failureMessage(dynamo.query(aws))
+        msg should include("Query")
+        msg should include("TheTable")
+        msg should include("TheKey")
       }
 
       "reporting batch write problems" in {
@@ -235,14 +252,21 @@ pekko.loggers = ["org.apache.pekko.testkit.TestEventListener"]
         val remove = WriteRequest.builder().deleteRequest(DeleteRequest.builder().key(key2Item).build()).build()
         val aws = BatchWriteItemRequest.builder()
           .requestItems(Map("TheTable" -> Seq(write, remove).asJava).asJava).build()
-        dynamo.batchWriteItem(aws).failed.futureValue.getMessage should
-        (include("BatchWriteItem").and(include("TheTable")))
+        val msg = failureMessage(dynamo.batchWriteItem(aws))
+        msg should include("BatchWriteItem")
+        msg should include("TheTable")
+        msg should include(s"put[$Key=TheKey,$Sort=42]")
+        msg should include(s"del[$Key=The2Key,$Sort=43]")
       }
 
       "reporting batch read problems" in {
         val ka = KeysAndAttributes.builder().keys(keyItem, key2Item).build()
         val aws = BatchGetItemRequest.builder().requestItems(Map("TheTable" -> ka).asJava).build()
-        dynamo.batchGetItem(aws).failed.futureValue.getMessage should (include("BatchGetItem").and(include("TheTable")))
+        val msg = failureMessage(dynamo.batchGetItem(aws))
+        msg should include("BatchGetItem")
+        msg should include("TheTable")
+        msg should include(s"[$Key=TheKey,$Sort=42]")
+        msg should include(s"[$Key=The2Key,$Sort=43]")
       }
     }
 

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/PartialAsyncSerializationSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/PartialAsyncSerializationSpec.scala
@@ -25,6 +25,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import scala.concurrent.duration._
+
 trait SerializeAsync
 
 case class TestAsyncMessage(sequence: Int) extends SerializeAsync
@@ -55,6 +57,8 @@ class PartialAsyncSerializationSpec
     with TypeCheckedTripleEquals
     with DynamoDBUtils
     with IntegSpec {
+
+  implicit val patience: PatienceConfig = PatienceConfig(5.seconds)
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/PersistAllConsistencySpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/PersistAllConsistencySpec.scala
@@ -24,6 +24,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import scala.concurrent.duration._
+
 class PersistAllConsistencySpec
     extends TestKit(ActorSystem("PersistAllConsistencySpec"))
     with ImplicitSender
@@ -34,6 +36,8 @@ class PersistAllConsistencySpec
     with TypeCheckedTripleEquals
     with DynamoDBUtils
     with IntegSpec {
+
+  implicit val patience: PatienceConfig = PatienceConfig(5.seconds)
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/RecoveryConsistencySpec.scala
@@ -22,7 +22,7 @@ import org.apache.pekko.persistence.query.PersistenceQuery
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.{ Materializer, SystemMaterializer }
 import org.apache.pekko.testkit._
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -189,6 +189,6 @@ class RecoveryConsistencySpec
     val key: Item = new JHMap
     key.put(Key, S(s"$JournalName-P-$persistenceId-${num / PartitionSize}"))
     key.put(Sort, N(num % PartitionSize))
-    dynamo.deleteItem(new DeleteItemRequest().withTableName(JournalTable).withKey(key)).futureValue
+    dynamo.deleteItem(DeleteItemRequest.builder().tableName(JournalTable).key(key).build()).futureValue
   }
 }

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBUtils.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBUtils.scala
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.persistence.dynamodb.snapshot
 
-import com.amazonaws.services.dynamodbv2.model._
+import software.amazon.awssdk.services.dynamodb.model._
 import org.apache.pekko
 import pekko.persistence.dynamodb.dynamoClient
 import pekko.persistence.dynamodb.journal.DynamoDBHelper
@@ -41,37 +41,38 @@ trait DynamoDBUtils {
 
   implicit val timeout: Timeout = Timeout(5.seconds)
 
-  import com.amazonaws.services.dynamodbv2.model.{ KeySchemaElement, KeyType }
-
-  val schema = new CreateTableRequest()
-    .withAttributeDefinitions(
-      new AttributeDefinition().withAttributeName(Key).withAttributeType("S"),
-      new AttributeDefinition().withAttributeName(SequenceNr).withAttributeType("N"),
-      new AttributeDefinition().withAttributeName(Timestamp).withAttributeType("N"))
-    .withKeySchema(
-      new KeySchemaElement().withAttributeName(Key).withKeyType(KeyType.HASH),
-      new KeySchemaElement().withAttributeName(SequenceNr).withKeyType(KeyType.RANGE))
-    .withLocalSecondaryIndexes(
-      new LocalSecondaryIndex()
-        .withIndexName(TimestampIndex)
-        .withKeySchema(
-          new KeySchemaElement().withAttributeName(Key).withKeyType(KeyType.HASH),
-          new KeySchemaElement().withAttributeName(Timestamp).withKeyType(KeyType.RANGE))
-        .withProjection(new Projection().withProjectionType(ProjectionType.ALL)))
+  val schema = CreateTableRequest.builder()
+    .attributeDefinitions(
+      AttributeDefinition.builder().attributeName(Key).attributeType(ScalarAttributeType.S).build(),
+      AttributeDefinition.builder().attributeName(SequenceNr).attributeType(ScalarAttributeType.N).build(),
+      AttributeDefinition.builder().attributeName(Timestamp).attributeType(ScalarAttributeType.N).build())
+    .keySchema(
+      KeySchemaElement.builder().attributeName(Key).keyType(KeyType.HASH).build(),
+      KeySchemaElement.builder().attributeName(SequenceNr).keyType(KeyType.RANGE).build())
+    .localSecondaryIndexes(
+      LocalSecondaryIndex.builder()
+        .indexName(TimestampIndex)
+        .keySchema(
+          KeySchemaElement.builder().attributeName(Key).keyType(KeyType.HASH).build(),
+          KeySchemaElement.builder().attributeName(Timestamp).keyType(KeyType.RANGE).build())
+        .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+        .build())
 
   def ensureSnapshotTableExists(read: Long = 10L, write: Long = 10L): Unit = {
-    val create = schema.withTableName(Table).withProvisionedThroughput(new ProvisionedThroughput(read, write))
+    val create = schema.tableName(Table)
+      .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(read).writeCapacityUnits(write).build())
+      .build()
 
     var names = Vector.empty[String]
-    lazy val complete: ListTablesResult => Future[Vector[String]] = aws =>
-      if (aws.getLastEvaluatedTableName == null) Future.successful(names ++ aws.getTableNames.asScala)
+    lazy val complete: ListTablesResponse => Future[Vector[String]] = aws =>
+      if (aws.lastEvaluatedTableName == null) Future.successful(names ++ aws.tableNames.asScala)
       else {
-        names ++= aws.getTableNames.asScala
+        names ++= aws.tableNames.asScala
         client
-          .listTables(new ListTablesRequest().withExclusiveStartTableName(aws.getLastEvaluatedTableName))
+          .listTables(ListTablesRequest.builder().exclusiveStartTableName(aws.lastEvaluatedTableName).build())
           .flatMap(complete)
       }
-    val list = client.listTables(new ListTablesRequest).flatMap(complete)
+    val list = client.listTables(ListTablesRequest.builder().build()).flatMap(complete)
 
     val setup = for {
       exists <- list.map(_ contains Table)

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBUtils.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/snapshot/DynamoDBUtils.scala
@@ -41,7 +41,8 @@ trait DynamoDBUtils {
 
   implicit val timeout: Timeout = Timeout(5.seconds)
 
-  val schema = CreateTableRequest.builder()
+  // a def, not a val: CreateTableRequest.Builder is mutable, so each caller needs its own
+  def schema: CreateTableRequest.Builder = CreateTableRequest.builder()
     .attributeDefinitions(
       AttributeDefinition.builder().attributeName(Key).attributeType(ScalarAttributeType.S).build(),
       AttributeDefinition.builder().attributeName(SequenceNr).attributeType(ScalarAttributeType.N).build(),


### PR DESCRIPTION
### Motivation

The plugin was built on the AWS SDK for Java v1, which reached end-of-support in December 2025 and no longer receives updates. Version 2.x of this plugin targets Pekko 2.0, Scala 2.13/3 and JDK 17, so it is the right place to move to the AWS SDK for Java v2.

### Modification

- Replace `com.amazonaws:aws-java-sdk-core` and `aws-java-sdk-dynamodb` with `software.amazon.awssdk:dynamodb`. The `javax.xml.bind:jaxb-api` workaround is no longer needed and has been dropped.
- Port the whole plugin - journal, snapshot store and read journal - to the v2 model: immutable request/response builders, `SdkBytes` in place of `ByteBuffer`, `XxxResponse` in place of `XxxResult`, `ScalarAttributeType` in place of the raw type strings, and `DynamoDbAsyncClient` in place of `AmazonDynamoDBAsync`.
- Replace the `AsyncHandler` callback plumbing in `DynamoDBHelper` with `CompletableFuture` conversion, and fold the `Describe` typeclass into by-name description strings at each call site.
- Add a `region` setting. The v2 client requires a region for request signing, so this falls back to `us-east-1` when a custom endpoint is configured, for example DynamoDB Local. An identifier that is not known to the SDK is logged as a warning, since `Region.of` accepts any non-blank string.
- Remove the `aws-client-config` block. It mapped directly onto the v1 `ClientConfiguration` class and has no v2 equivalent. This is a breaking configuration change and is documented in the README.
- Rewrite `getUnprocessedItems` to accumulate items across retries instead of mutating the response in place, which the v2 model does not allow.

### Result

The plugin runs on a supported AWS SDK. Behaviour is unchanged: retry and backoff semantics, item layout and table schema are all the same, so no data migration is required.

This is a breaking change for anyone configuring `aws-client-config`, which is silently ignored from 2.x onward. Applications that pass an `AmazonDynamoDB` client or reference the v1 model types directly will need updating.

### Tests

- `sbt scalafmtCheckAll` - pass
- `sbt compile Test/compile` - pass on 2.13.18 and 3.8.4
- DynamoDB integration tests - not run locally, Docker unavailable in the development environment; covered by CI
- `FailureReportingSpec` was reworked to assert on the failure messages the new code produces, keeping coverage of the formatted request descriptions
- `BackwardsCompatibilityV1Spec` still verifies that events written in the old format are readable, now writing them through the v2 client

### References

None - AWS SDK for Java v1 is end-of-support, see https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/
