### PR TITLE
chore: remove leftover Scala 2.12 idioms

### DIFF
--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournal.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBJournal.scala
@@ -25,7 +25,6 @@ import org.apache.pekko.stream.{ Materializer, SystemMaterializer }
 import com.amazonaws.services.dynamodbv2.model._
 import com.typesafe.config.Config
 
-import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.{ Success, Try }
 
@@ -107,7 +106,7 @@ class DynamoDBJournal(config: Config)
   private case class OpFinished(pid: String, f: Future[Done])
   private val opQueue: JMap[String, Future[Done]] = new JHMap
 
-  override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     val p = Promise[Done]()
     val pid = messages.head.persistenceId
     opQueue.put(pid, p.future)

--- a/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
+++ b/src/main/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoDBRecovery.scala
@@ -60,7 +60,7 @@ object DynamoDBRecovery {
  * @param partitionSeqNum - the partition sequence number for the given persistence id.
  * @param partitionEventNums - will be 0-99, representing the event ordering within the given partition sequence.
  */
-case class PartitionKeys(partitionSeqNum: Long, partitionEventNums: immutable.Seq[Long])
+case class PartitionKeys(partitionSeqNum: Long, partitionEventNums: Seq[Long])
 
 /**
  * Groups Longs from a stream into a [PartitionKeys] whereas each sequence shall contain the values that would be within the

--- a/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
+++ b/src/test/scala/org/apache/pekko/persistence/dynamodb/journal/DynamoPartitionGroupedSpec.scala
@@ -50,7 +50,7 @@ class DynamoPartitionGroupedSpec extends TestKit(ActorSystem("DynamoPartitionGro
         .request(1)
         .expectNext(PartitionKeys(2L, 200L to 299))
         .request(1)
-        .expectNext(PartitionKeys(3L, scala.collection.immutable.Seq(300L)))
+        .expectNext(PartitionKeys(3L, Seq(300L)))
         .expectComplete()
     }
 


### PR DESCRIPTION
### Motivation
Port of apache/pekko#3539 to this repo. The codebase still carried `immutable.Seq` qualifiers, a Scala 2.12-era idiom that is redundant on Scala 2.13/3, where `scala.Seq` is already a type alias for `scala.collection.immutable.Seq`.

Of the other idioms cleaned up in the pekko PR (`WrappedArray`, `filterKeys`/`mapValues`, `Either` left/right projections, `.toIterator`, `Stream`), none are present in this repo.

### Modification
- `DynamoDBJournal.asyncWriteMessages`: `immutable.Seq[AtomicWrite]` / `Future[immutable.Seq[Try[Unit]]]` -> `Seq[...]`, dropping the now-unused `scala.collection.immutable` import.
- `PartitionKeys.partitionEventNums`: `immutable.Seq[Long]` -> `Seq[Long]`. The `immutable` import in `DynamoDBRecovery` stays since `immutable.Iterable` / `immutable.TreeMap` still use it.
- `DynamoPartitionGroupedSpec`: `scala.collection.immutable.Seq(300L)` -> `Seq(300L)`.

Same erasure, so this is source- and binary-compatible.

### Result
No remaining Scala 2.12 collection idioms in main or test sources.

### Tests
- `scalafmt --list --mode diff-ref=upstream/main` (clean)
- `sbt +Test/compile` (Scala 2.13.18, 3.3.8, 3.9.0)
- `sbt "testOnly org.apache.pekko.persistence.dynamodb.journal.DynamoPartitionGroupedSpec"` - 5/5 pass
- `sbt mimaReportBinaryIssues` reports 2 problems on `DynamoDBHelper.dynamoDB` (result type `AmazonDynamoDBAsyncClient` -> `AmazonDynamoDBAsync` vs 1.0.0). These are pre-existing and fail identically on `main` without this change; nothing new is introduced here.

### References
Refs apache/pekko#3539
